### PR TITLE
Fixed 'sonar.libraries' property population

### DIFF
--- a/src/main/java/org/sonarqube/gradle/SonarQubePlugin.java
+++ b/src/main/java/org/sonarqube/gradle/SonarQubePlugin.java
@@ -299,7 +299,7 @@ public class SonarQubePlugin implements Plugin<Project> {
         appendProp(properties, "sonar.groovy.binaries", mainClassDir);
       }
       // Populate deprecated properties for backward compatibility
-      appendProp(properties, "sonar.binaries", mainClassDir);
+      appendProps(properties, "sonar.binaries", mainClassDir);
     }
 
     appendProps(properties, "sonar.java.libraries", mainLibraries);

--- a/src/main/java/org/sonarqube/gradle/SonarQubePlugin.java
+++ b/src/main/java/org/sonarqube/gradle/SonarQubePlugin.java
@@ -299,12 +299,12 @@ public class SonarQubePlugin implements Plugin<Project> {
         appendProp(properties, "sonar.groovy.binaries", mainClassDir);
       }
       // Populate deprecated properties for backward compatibility
-      appendProps(properties, "sonar.binaries", mainClassDir);
+      appendProp(properties, "sonar.binaries", mainClassDir);
     }
 
     appendProps(properties, "sonar.java.libraries", mainLibraries);
     // Populate deprecated properties for backward compatibility
-    appendProp(properties, "sonar.libraries", mainLibraries);
+    appendProps(properties, "sonar.libraries", mainLibraries);
   }
 
   static void appendProps(Map<String, Object> properties, String key, Iterable valuesToAppend) {


### PR DESCRIPTION
Fixed 'sonar.libraries' population: library paths were incorrectly being added as a single property, resulting in exceptions during the sonar run as the following:

```
Caused by: java.lang.IllegalStateException: No files nor directories matching '[/path/to/home/.gradle/caches/modules-2/files-2.1/com.example/some-library/1.0/7a885b1624285ea1a7b91fbd31040554a6385a10/some-library-1.0.jar' in directory /path/to/home/my-project
    at org.sonar.batch.scan.ProjectReactorBuilder.validateDirectories(ProjectReactorBuilder.java:302)
```