### PR TITLE
Filter 'sonar.java[.test].libraries' to only valid entries

### DIFF
--- a/src/main/java/org/sonarqube/gradle/AndroidUtils.java
+++ b/src/main/java/org/sonarqube/gradle/AndroidUtils.java
@@ -197,7 +197,7 @@ class AndroidUtils {
       libraries.addAll(((ApkVariant) variant).getCompileLibraries());
     }
     if (javaCompiler != null) {
-      libraries.addAll(javaCompiler.getClasspath().getFiles());
+      libraries.addAll(javaCompiler.getClasspath().filter(File::exists).getFiles());
     }
     if (isTest) {
       SonarQubePlugin.setTestClasspathProps(properties, javaCompiler != null ? javaCompiler.getDestinationDir() : null, libraries);


### PR DESCRIPTION
Added filtering for classpath entries to keep only the ones which are available on the file system. This is needed to make sure that the sonar.java[.test].libraries properties contain only valid entries.

Otherwise an java.lang.IllegalStateException is thrown, i.e. for `{project.buildDir}/intermediates/dependency-cache/{variantName}`

```
+ ./gradlew -v

------------------------------------------------------------
Gradle 3.3
------------------------------------------------------------

Build time:   2017-01-03 15:31:04 UTC
Revision:     075893a3d0798c0c1f322899b41ceca82e4e134b

Groovy:       2.4.7
Ant:          Apache Ant(TM) version 1.9.6 compiled on June 29 2015
JVM:          1.8.0_45 (Oracle Corporation 25.45-b02)
OS:           Linux 3.10.0-229.11.1.el7.x86_64 amd64

------------------------------------------------------------
sonarqube-gradle-plugin:    2.2.1
------------------------------------------------------------
```

```
:sonarqubeInvalid value for sonar.java.test.libraries
 FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':sonarqube'.
> No files nor directories matching '.../build/intermediates/dependency-cache/debug'

* Try:
Run with --info or --debug option to get more log output.

* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':sonarqube'.
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:84)
	...
Caused by: java.lang.IllegalStateException: No files nor directories matching '.../build/intermediates/dependency-cache/debug'
	at org.sonar.java.AbstractJavaClasspath.getFilesFromProperty(AbstractJavaClasspath.java:92)
	at org.sonar.java.JavaTestClasspath.init(JavaTestClasspath.java:48)
	at org.sonar.java.AbstractJavaClasspath.getElements(AbstractJavaClasspath.java:276)
	at org.sonar.java.SonarComponents.getJavaTestClasspath(SonarComponents.java:137)
	at org.sonar.java.JavaSquid.<init>(JavaSquid.java:79)
```

Similar report: https://groups.google.com/forum/#!topic/sonarqube/PIV5kmJFY58