### PR TITLE
Remove dependency on internal Gradle class, renamed in 3.5

### DIFF
--- a/src/main/java/org/sonarqube/gradle/ActionBroadcast.java
+++ b/src/main/java/org/sonarqube/gradle/ActionBroadcast.java
@@ -1,0 +1,39 @@
+/**
+ * SonarQube Gradle Plugin
+ * Copyright (C) 2015-2016 SonarSource
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonarqube.gradle;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.gradle.api.Action;
+
+public class ActionBroadcast<T> implements Action<T> {
+
+  private final List<Action<? super T>> actions = new ArrayList<>();
+
+  public void add(Action<? super T> action) {
+    actions.add(action);
+  }
+
+  @Override
+  public void execute(T t) {
+    actions.forEach((a) -> a.execute(t));
+  }
+
+}

--- a/src/main/java/org/sonarqube/gradle/SonarQubeExtension.java
+++ b/src/main/java/org/sonarqube/gradle/SonarQubeExtension.java
@@ -20,7 +20,6 @@
 package org.sonarqube.gradle;
 
 import org.gradle.api.Action;
-import org.gradle.listener.ActionBroadcast;
 
 /**
  * An extension for configuring the <a href="http://docs.sonarqube.org/display/SONAR/Analyzing+with+Gradle">SonarQube</a> analysis.

--- a/src/main/java/org/sonarqube/gradle/SonarQubePlugin.java
+++ b/src/main/java/org/sonarqube/gradle/SonarQubePlugin.java
@@ -50,7 +50,6 @@ import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.testing.Test;
-import org.gradle.listener.ActionBroadcast;
 import org.gradle.testing.jacoco.plugins.JacocoPlugin;
 import org.gradle.testing.jacoco.plugins.JacocoTaskExtension;
 import org.sonarsource.scanner.api.Utils;

--- a/src/test/groovy/org/sonarqube/gradle/SonarQubeExtensionTest.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/SonarQubeExtensionTest.groovy
@@ -19,7 +19,6 @@
  */
 package org.sonarqube.gradle
 
-import org.gradle.listener.ActionBroadcast
 import spock.lang.Specification
 
 class SonarQubeExtensionTest extends Specification {


### PR DESCRIPTION
Applying the SonarQube Gradle Plugin to a Gradle build using the next release version (3.5) fails with the error `java.lang.ClassNotFoundException: org.gradle.listener.ActionBroadcast`.

The class `org.gradle.listener.ActionBroadcast` is an internal implementation class in Gradle. In Gradle 3.5, the class has been renamed, refactored, and moved to an internal package.

This PR removes the dependency on the internal class and implements a simple replacement class with the only two methods used by the plugin.