### PR TITLE
Updates jacoco to 0.8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ license {
 }
 
 jacoco {
-  toolVersion = "0.7.6.201602180812"
+  toolVersion = "0.8.0"
 }
 
 // Add required informations to deploy on central


### PR DESCRIPTION
Prior to Jacoco 0.8.0, there was no way to filter out lombok generated code from test coverage with Jacoco. This makes it very hard to get accurate test coverage reporting in sonarqube. In a project I am working on, there's a 30% discrepancy between reported LoC in jacoco itself and sonarqube. Updating to 0.8.0 should alleviate this issue. Context: https://github.com/jacoco/jacoco/pull/513#issuecomment-293176354

Please consider making this update!