### PR TITLE
Allow tests to be skipped

### DIFF
--- a/src/main/java/org/sonarqube/gradle/SonarQubeExtension.java
+++ b/src/main/java/org/sonarqube/gradle/SonarQubeExtension.java
@@ -59,6 +59,7 @@ public class SonarQubeExtension {
   private boolean skipProject;
   private final ActionBroadcast<SonarQubeProperties> propertiesActions;
   private String androidVariant;
+  private boolean skipTests;
 
   public SonarQubeExtension(ActionBroadcast<SonarQubeProperties> propertiesActions) {
     this.propertiesActions = propertiesActions;
@@ -107,5 +108,13 @@ public class SonarQubeExtension {
 
   public void setAndroidVariant(String androidVariant) {
     this.androidVariant = androidVariant;
+  }
+
+  public boolean isSkipTests() {
+    return skipTests;
+  }
+
+  public void setSkipTests(boolean skipTests) {
+    this.skipTests = skipTests;
   }
 }

--- a/src/main/java/org/sonarqube/gradle/SonarQubePlugin.java
+++ b/src/main/java/org/sonarqube/gradle/SonarQubePlugin.java
@@ -90,6 +90,7 @@ public class SonarQubePlugin implements Plugin<Project> {
       .computeSonarProperties());
 
     Callable<Iterable<? extends Task>> testTasks = () -> project.getAllprojects().stream()
+      .filter(p -> !project.getExtensions().getByType(SonarQubeExtension.class).isSkipTests())
       .filter(p -> p.getPlugins().hasPlugin(JavaPlugin.class) && !p.getExtensions().getByType(SonarQubeExtension.class).isSkipProject())
       .map(p -> p.getTasks().getByName(JavaPlugin.TEST_TASK_NAME))
       .collect(Collectors.toList());

--- a/src/test/groovy/org/sonarqube/gradle/SonarQubePluginTest.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/SonarQubePluginTest.groovy
@@ -29,6 +29,7 @@ import spock.lang.Specification
 
 import static org.hamcrest.Matchers.contains
 import static org.hamcrest.Matchers.containsInAnyOrder
+import static org.hamcrest.Matchers.not
 import static spock.util.matcher.HamcrestSupport.expect
 
 class SonarQubePluginTest extends Specification {
@@ -98,6 +99,18 @@ class SonarQubePluginTest extends Specification {
         parentSonarQubeTask().description == "Analyzes project ':parent' and its subprojects with SonarQube."
 
         childProject.tasks.findByName("sonarqube") == null
+    }
+
+    def "doesn't make sonarqube task depend on test tasks when skipTests is true"() {
+        when:
+        rootProject.pluginManager.apply(JavaPlugin)
+        parentProject.pluginManager.apply(JavaPlugin)
+        childProject.pluginManager.apply(JavaPlugin)
+        parentProject.sonarqube.skipTests = true
+
+        then:
+        expect(parentSonarQubeTask(), TaskDependencyMatchers.dependsOnPaths(not(contains(":parent:test"))))
+        expect(parentSonarQubeTask(), TaskDependencyMatchers.dependsOnPaths(not(contains(":parent:child:test"))))
     }
 
     def "makes sonarqube task depend on test tasks of the target project and its subprojects"() {


### PR DESCRIPTION
 - Conditionally skip adding test tasks to sonarqube task dependencies

This is intended to answer [How do I prevent the Gradle sonarqube task from running tests?](https://community.sonarsource.com/t/how-do-i-prevent-the-gradle-sonarqube-task-from-running-tests/6674/4) on the SonarSource Community.