### PR TITLE
Use BaseVariant.getJavaCompileProvider() where available

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ repositories {
 dependencies {
   compile gradleApi()
   compile 'org.sonarsource.scanner.api:sonar-scanner-api:2.12.0.1661'
-  compileOnly 'com.android.tools.build:gradle:3.1.0'
+  compileOnly 'com.android.tools.build:gradle:3.3.0'
   compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
   testCompile localGroovy()
   testCompile 'junit:junit:4.12'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/org/sonarqube/gradle/AndroidUtils.java
+++ b/src/main/java/org/sonarqube/gradle/AndroidUtils.java
@@ -48,7 +48,9 @@ import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.PluginCollection;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.compile.AbstractCompile;
+import org.gradle.api.tasks.compile.JavaCompile;
 import org.jetbrains.annotations.NotNull;
 
 import static org.sonarqube.gradle.SonarPropertyComputer.SONAR_JAVA_SOURCE_PROP;
@@ -228,7 +230,8 @@ class AndroidUtils {
 
   @Nullable
   private static AbstractCompile getJavaCompiler(BaseVariant variant) {
-    return variant.getJavaCompile();
+    TaskProvider<JavaCompile> taskProvider = variant.getJavaCompileProvider();
+    return taskProvider != null ? taskProvider.get() : null;
   }
 
   private static List<File> getFilesFromSourceSet(SourceProvider sourceSet) {

--- a/src/main/java/org/sonarqube/gradle/AndroidUtils.java
+++ b/src/main/java/org/sonarqube/gradle/AndroidUtils.java
@@ -230,8 +230,15 @@ class AndroidUtils {
 
   @Nullable
   private static AbstractCompile getJavaCompiler(BaseVariant variant) {
-    TaskProvider<JavaCompile> taskProvider = variant.getJavaCompileProvider();
-    return taskProvider != null ? taskProvider.get() : null;
+    try {
+      Method methodOnAndroidBefore33 = variant.getClass().getMethod("getJavaCompile");
+      return (AbstractCompile) methodOnAndroidBefore33.invoke(variant);
+    } catch (NoSuchMethodException e) {
+      TaskProvider<JavaCompile> taskProvider = variant.getJavaCompileProvider();
+      return taskProvider != null ? taskProvider.get() : null;
+    } catch (IllegalAccessException | InvocationTargetException e) {
+      throw new IllegalArgumentException("Unable to call getJavaCompile", e);
+    }
   }
 
   private static List<File> getFilesFromSourceSet(SourceProvider sourceSet) {


### PR DESCRIPTION
This ensures compatibility of the ```sonarqube``` task with Gradle 5.

Updated the Gradle plugin to version ```3.3.0``` and the Gradle wrapper to version ```4.10.1```.