### PR TITLE
Improvement to memory leak concerning SonarQubePlugin#actionBroadcastMap

### DIFF
--- a/src/main/java/org/sonarqube/gradle/SonarPropertyComputer.java
+++ b/src/main/java/org/sonarqube/gradle/SonarPropertyComputer.java
@@ -67,10 +67,10 @@ public class SonarPropertyComputer {
   static final String SONAR_JAVA_SOURCE_PROP = "sonar.java.source";
   static final String SONAR_JAVA_TARGET_PROP = "sonar.java.target";
 
-  private final Map<Project, ActionBroadcast<SonarQubeProperties>> actionBroadcastMap;
+  private final Map<String, ActionBroadcast<SonarQubeProperties>> actionBroadcastMap;
   private final Project targetProject;
 
-  public SonarPropertyComputer(Map<Project, ActionBroadcast<SonarQubeProperties>> actionBroadcastMap, Project targetProject) {
+  public SonarPropertyComputer(Map<String, ActionBroadcast<SonarQubeProperties>> actionBroadcastMap, Project targetProject) {
     this.actionBroadcastMap = actionBroadcastMap;
     this.targetProject = targetProject;
   }
@@ -93,7 +93,7 @@ public class SonarPropertyComputer {
       AndroidUtils.configureForAndroid(project, extension.getAndroidVariant(), rawProperties);
     }
 
-    ActionBroadcast<SonarQubeProperties> actionBroadcast = actionBroadcastMap.get(project);
+    ActionBroadcast<SonarQubeProperties> actionBroadcast = actionBroadcastMap.get(project.getPath());
     if (actionBroadcast != null) {
       evaluateSonarPropertiesBlocks(actionBroadcast, rawProperties);
     }

--- a/src/main/java/org/sonarqube/gradle/SonarQubePlugin.java
+++ b/src/main/java/org/sonarqube/gradle/SonarQubePlugin.java
@@ -45,11 +45,11 @@ import static org.sonarqube.gradle.SonarUtils.isAndroidProject;
 public class SonarQubePlugin implements Plugin<Project> {
 
   private static final Logger LOGGER = Logging.getLogger(SonarQubePlugin.class);
-  private static final Map<Project, ActionBroadcast<SonarQubeProperties>> actionBroadcastMap = new HashMap<>();
+  private static final Map<String, ActionBroadcast<SonarQubeProperties>> actionBroadcastMap = new HashMap<>();
 
   private ActionBroadcast<SonarQubeProperties> addBroadcaster(Project project) {
     ActionBroadcast<SonarQubeProperties> actionBroadcast = new ActionBroadcast<>();
-    actionBroadcastMap.put(project, actionBroadcast);
+    actionBroadcastMap.put(project.getPath(), actionBroadcast);
     return actionBroadcast;
   }
 


### PR DESCRIPTION
This PR alleviates a memory leak around `SonarQubePlugin#actionBroadcastMap`.

The problem was reported here: https://community.sonarsource.com/t/memory-leaks-in-sonarqube-gradle-plugin-2-7-and-2-6-2/6165

This PR does not fully fix the issue, but improves upon the current situation by changing the map lookup key to the project name, instead of the full gradle projects.
This enables the gradle daemon to become memory stable again in our development environment.