### PR TITLE
Fixing a warning

### DIFF
--- a/src/main/java/org/sonarqube/gradle/AndroidUtils.java
+++ b/src/main/java/org/sonarqube/gradle/AndroidUtils.java
@@ -189,7 +189,7 @@ class AndroidUtils {
       appendProps(properties, isTest ? SONAR_TESTS_PROP : SONAR_SOURCES_PROP, sourcesOrTests);
     }
 
-    AbstractCompile javaCompiler = getJavaCompiler(variant);
+    AbstractCompile javaCompiler = getJavaCompileProvider(variant);
     if (javaCompiler == null) {
       LOGGER.warn("Unable to find Java compiler on variant '{}'. Is Jack toolchain used? SonarQube analysis will be less accurate without bytecode.", variant.getName());
     }


### PR DESCRIPTION
Fixing the warning -

WARNING: API 'variant.getJavaCompile()' is obsolete and has been replaced with 'variant.getJavaCompileProvider()'.
It will be removed at the end of 2019.

Please review our [contribution guidelines](https://github.com/SonarSource/sonar-scanner-gradle/blob/master/contributing.md).

And please ensure your pull request adheres to the following guidelines: 

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](https://jira.sonarsource.com/browse/SONARGRADL) ticket available, please make your commits and pull request start with the ticket ID (SONARGRADL-XXXX)
