### PR TITLE
Fixing a warning

### DIFF
--- a/src/main/java/org/sonarqube/gradle/AndroidUtils.java
+++ b/src/main/java/org/sonarqube/gradle/AndroidUtils.java
@@ -228,7 +228,7 @@ class AndroidUtils {
 
   @Nullable
   private static AbstractCompile getJavaCompiler(BaseVariant variant) {
-    return variant.getJavaCompile();
+    return variant.getJavaCompileProvider();
   }
 
   private static List<File> getFilesFromSourceSet(SourceProvider sourceSet) {


### PR DESCRIPTION
Fixing the warning -

WARNING: API 'variant.getJavaCompile()' is obsolete and has been replaced with 'variant.getJavaCompileProvider()'.
It will be removed at the end of 2019.

Please review our [contribution guidelines](https://github.com/SonarSource/sonar-scanner-gradle/blob/master/contributing.md).

And please ensure your pull request adheres to the following guidelines: 

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](https://jira.sonarsource.com/browse/SONARGRADL) ticket available, please make your commits and pull request start with the ticket ID (SONARGRADL-XXXX)
