### PR TITLE
Add group to `sonarqube` task

### DIFF
--- a/src/test/groovy/org/sonarqube/gradle/SonarQubePluginTest.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/SonarQubePluginTest.groovy
@@ -73,6 +73,7 @@ class SonarQubePluginTest extends Specification {
     def "adds a sonarqube task to the target project"() {
         expect:
         parentProject.tasks.findByName("sonarqube") instanceof SonarQubeTask
+        parentSonarQubeTask().group == JavaBasePlugin.VERIFICATION_GROUP
         parentSonarQubeTask().description == "Analyzes project ':parent' and its subprojects with SonarQube."
 
         childProject.tasks.findByName("sonarqube") == null


### PR DESCRIPTION
In Gradle, tasks can be inserted into groups. Tasks that have a group are already displayed by executing `/gradlew tasks`, while tasks without a group are only displayed by executing `/gradlew tasks --all`.

I have implemented that the task is added to the `Verification` group and also adapted the JUnit test to validate this.

I hope, since this is a trivial beauty change, that a pull request will suffice.