### PR TITLE
Support config-cache

### DIFF
--- a/src/main/java/org/sonarqube/gradle/SonarQubeTask.java
+++ b/src/main/java/org/sonarqube/gradle/SonarQubeTask.java
@@ -32,6 +32,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.util.GradleVersion;
 import org.sonarsource.scanner.api.EmbeddedScanner;
 import org.sonarsource.scanner.api.LogOutput;
 import org.sonarsource.scanner.api.ScanProperties;
@@ -95,7 +96,7 @@ public class SonarQubeTask extends ConventionTask {
       return;
     }
 
-    EmbeddedScanner scanner = EmbeddedScanner.create("ScannerGradle", getPluginVersion() + "/" + getProject().getGradle().getGradleVersion(), LOG_OUTPUT)
+    EmbeddedScanner scanner = EmbeddedScanner.create("ScannerGradle", getPluginVersion() + "/" + GradleVersion.current(), LOG_OUTPUT)
       .addGlobalProperties(properties);
     scanner.start();
     scanner.execute(new HashMap<>());


### PR DESCRIPTION
Calling Project from Task is forbidden for configuration cache. If
someone wants to enable it then he would see following error.
```
1 problem was found storing the configuration cache.
- Task `:sonarqube` of type `org.sonarqube.gradle.SonarQubeTask`:
  invocation of 'Task.project' at execution time is unsupported.
  See https://docs.gradle.org/6.8.3/userguide/configuration_cache.html
  #config_cache:requirements:use_project_during_execution
```

Thanks to that PR we can get rid of config cache fails.

At the moment I can't add a test as there is no support for jacoco agent
+ TestKit:
```
Configuration cache problems found in this build.

1 problem was found storing the configuration cache.
- Gradle runtime: support for using a Java agent with TestKit builds is
  not yet implemented with the configuration cache.
  See https://docs.gradle.org/6.8.3/userguide/configuration_cache.html#
  config_cache:not_yet_implemented:testkit_build_with_java_agent
```

When it would be implemented following test should be added to
`FunctionalTests`:
```groovy
def "pass build with configuration cache enabled"() {
    given:
    settingsFile << "rootProject.name = 'java-configuration-cache'"
    buildFile << """
    plugins {
        id 'org.sonarqube'
    }
    """
    when:
    def result = GradleRunner.create()
            .withProjectDir(testProjectDir.root)
            .withGradleVersion('6.8.3')
            .forwardOutput()
            .withArguments('sonarqube',
                '--configuration-cache',
                '--build-cache',
                '-Dsonar.scanner.dumpToFile=' + outFile.absolutePath)
            .withPluginClasspath()
            .build()
    then:
    result.task(":sonarqube").outcome == SUCCESS
}
```

Related to discussion:
https://community.sonarsource.com/t/sonarqube-gradle-plugin-should-support-the-gradle-configuration-cache/29455/3
