### PR TITLE
Replace deprecated Report method usage

### DIFF
--- a/src/main/java/org/sonarqube/gradle/SonarPropertyComputer.java
+++ b/src/main/java/org/sonarqube/gradle/SonarPropertyComputer.java
@@ -248,8 +248,8 @@ public class SonarPropertyComputer {
   private static void configureJaCoCoCoverageReport(final Test testTask, final boolean addForGroovy, Project project, final Map<String, Object> properties) {
     project.getTasks().withType(JacocoReport.class, jacocoReportTask -> {
       SingleFileReport xmlReport = jacocoReportTask.getReports().getXml();
-      if (xmlReport.isEnabled() && xmlReport.getDestination().exists()) {
-        appendProp(properties, "sonar.coverage.jacoco.xmlReportPaths", xmlReport.getDestination());
+      if (xmlReport.getRequired().get() && xmlReport.getOutputLocation().getAsFile().getOrNull().exists()) {
+        appendProp(properties, "sonar.coverage.jacoco.xmlReportPaths", xmlReport.getOutputLocation().getAsFile().getOrNull());
       } else {
         LOGGER.info("JaCoCo report task detected, but XML report is not enabled or it was not produced. " +
           "Coverage for this task will not be reported.");
@@ -270,7 +270,7 @@ public class SonarPropertyComputer {
   }
 
   private static void configureTestReports(Test testTask, Map<String, Object> properties) {
-    File testResultsDir = testTask.getReports().getJunitXml().getDestination();
+    File testResultsDir = testTask.getReports().getJunitXml().getOutputLocation().getAsFile().getOrNull();
 
     // do not set a custom test reports path if it does not exists, otherwise SonarQube will emit an error
     // do not set a custom test reports path if there are no files, otherwise SonarQube will emit a warning


### PR DESCRIPTION
This PR may serve as a guidance on how to fix the following issue: https://community.sonarsource.com/t/report-enabled-and-report-destination-are-deprecated-and-will-be-removed-in-gradle-8-0/50491/3

`getRequired()` is marked as _Incubating_ in Gradle 6.7. But I guess you're already planing on migrating to Gradle 7.x.
