### PR TITLE
Do not use deprecated Report methods backwards compatibly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,7 @@ jacoco {
 
 jacocoTestReport {
   reports {
-    xml.enabled true
+    xml.required = true
   }
 }
 


### PR DESCRIPTION
https://jira.sonarsource.com/browse/SONARGRADL-84

Fix Gradle's deprecation warnings so that the plugin is compatible with the next major version 8.0.

Perform a runtime check for the Gradle version to maintain backwards compatibility.