### PR TITLE
Add sleep add the end of the gradle execution as a workaround on zipping cache issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -240,3 +240,9 @@ tasks.withType(Sign) {
       gradle.taskGraph.hasTask(":artifactoryPublish")
   }
 }
+
+tasks.withType(Test).configureEach {
+  doLast {
+    Thread.sleep(2000) // https://github.com/gradle/gradle/issues/16603
+  }
+}


### PR DESCRIPTION
Fix based on a workaround for this issue: https://github.com/gradle/gradle/issues/16603