### PR TITLE
Compatibility with gradle 8.0.

### DIFF
--- a/sonar-docs/analysis/scan/sonarscanner-for-gradle.md
+++ b/sonar-docs/analysis/scan/sonarscanner-for-gradle.md
@@ -14,7 +14,7 @@ The SonarScanner for Gradle provides an easy way to start SonarQube analysis of 
 The ability to execute the SonarQube analysis via a regular Gradle task makes it available anywhere Gradle is available (developer build, CI server, etc.), without the need to manually download, setup, and maintain a SonarQube Runner installation. The Gradle build already has much of the information needed for SonarQube to successfully analyze a project. By preconfiguring the analysis based on that information, the need for manual configuration is reduced significantly. 
 
 ## Prerequisites
-* Gradle versions 2.14+
+* Gradle versions 6.1+
 * At least the minimal version of Java supported by your SonarQube server is in use 
 
 Bytecode created by javac compilation is required for Java analysis, including Android projects.

--- a/src/main/java/org/sonarqube/gradle/SonarPropertyComputer.java
+++ b/src/main/java/org/sonarqube/gradle/SonarPropertyComputer.java
@@ -410,23 +410,15 @@ public class SonarPropertyComputer {
   }
 
   private static boolean isReportEnabled(Report report) {
-    if (GradleVersion.version("7.0").compareTo(GradleVersion.current()) <= 0) {
-      return report.getRequired().getOrElse(false);
-    } else {
-      return report.isEnabled();
-    }
+    return report.getRequired().getOrElse(false);
   }
 
   @CheckForNull
   private static File getDestination(Report report) {
-    if (GradleVersion.version("7.0").compareTo(GradleVersion.current()) <= 0) {
-      FileSystemLocation location = report.getOutputLocation().getOrNull();
-      if (location != null) {
-        return location.getAsFile();
-      }
-      return null;
-    } else {
-      return report.getDestination();
+    FileSystemLocation location = report.getOutputLocation().getOrNull();
+    if (location != null) {
+      return location.getAsFile();
     }
+    return null;
   }
 }

--- a/src/test/groovy/org/sonarqube/gradle/SonarQubePluginTest.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/SonarQubePluginTest.groovy
@@ -255,9 +255,9 @@ class SonarQubePluginTest extends Specification {
 
         project.sourceSets.main.java.srcDirs = ["src"]
         project.sourceSets.test.java.srcDirs = ["test"]
-        project.sourceSets.main.java.outputDir = new File(project.buildDir, "out")
+        project.sourceSets.main.java.destinationDirectory.set(new File(project.buildDir, "out"))
         project.sourceSets.main.compileClasspath += project.files("lib/SomeLib.jar")
-        project.sourceSets.test.java.outputDir = new File(project.buildDir, "test-out")
+        project.sourceSets.test.java.destinationDirectory.set(new File(project.buildDir, "test-out"))
         project.sourceSets.test.compileClasspath += project.files("lib/junit.jar")
         project.compileJava.options.encoding = 'ISO-8859-1'
 
@@ -313,9 +313,9 @@ class SonarQubePluginTest extends Specification {
         project.sourceSets.main.groovy.srcDirs = ["src"]
         project.sourceSets.test.groovy.srcDirs = ["test"]
         project.sourceSets.main.output.classesDirs.setFrom(new File(project.buildDir, "out"))
-        project.sourceSets.main.java.outputDir = new File(project.buildDir, "out")
+        project.sourceSets.main.java.destinationDirectory.set(new File(project.buildDir, "out"))
         project.sourceSets.main.compileClasspath += project.files("lib/SomeLib.jar")
-        project.sourceSets.test.java.outputDir = new File(project.buildDir, "test-out")
+        project.sourceSets.test.java.destinationDirectory.set(new File(project.buildDir, "test-out"))
         project.sourceSets.test.compileClasspath += project.files("lib/junit.jar")
         project.compileJava.options.encoding = 'ISO-8859-1'
 


### PR DESCRIPTION
This PR provides compatibility with upcoming gradle 8.0.

Note that the required minimum version must be bumped to 6.1 with this patch (this is when destinationDirectory property appeared).

Not bumping minimum version to 6.1 would require reflection as some properties are removed in 8.0 and it cannot be compiled with that version. I'm unsure if this is what you want.

Unit tests pass, changes are minimum
