### PR TITLE
NO-JIRA fixed an issue where building a project failed on JDK >= 13

### DIFF
--- a/src/main/java/org/sonarqube/gradle/SonarExtension.java
+++ b/src/main/java/org/sonarqube/gradle/SonarExtension.java
@@ -37,7 +37,7 @@ import org.gradle.api.Action;
  *   }
  * }
  * </pre>
- * <h3>Sonar Properties</h3>
+ * <h2>Sonar Properties</h2>
  * <p>
  * The Sonar configuration is provided by using the {@link #properties(org.gradle.api.Action)} method and specifying properties.
  * Certain properties are required, such as {@code "sonar.host.url"} which provides the address of the server.


### PR DESCRIPTION
Change in Java: https://bugs.openjdk.org/browse/JDK-8220379

Otherwise the build fails with message:

`C:\me\git\sonar-scanner-gradle\src\main\java\org\sonarqube\gradle\SonarExtension.java:40: error: heading used out of sequence: <H3>, compared to implicit preceding heading: <H1>
`
