### PR TITLE
Support Gradle 8

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -141,6 +141,7 @@ gradle_qa_java17_task:
     matrix:
       - GRADLE_VERSION: 7.4.1
         ANDROID_GRADLE_VERSION: 7.1.0
+      - GRADLE_VERSION: 8.0-rc-2
   gradle_cache:
     folder: ~/.gradle/caches
   script:

--- a/cirrus/cirrus-qa.sh
+++ b/cirrus/cirrus-qa.sh
@@ -18,7 +18,11 @@ cd integrationTests
 mvn org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion=$NEW_VERSION -DgenerateBackupPoms=false -B -e
 
 # Execute ITs
-mvn -e -B clean verify -Dgradle.version=$GRADLE_VERSION -DandroidGradle.version=$ANDROID_GRADLE_VERSION
+if [ -v ANDROID_GRADLE_VERSION ]; then
+  mvn -e -B clean verify -Dgradle.version=$GRADLE_VERSION -DandroidGradle.version=$ANDROID_GRADLE_VERSION
+else
+  mvn -e -B clean verify -Dgradle.version=$GRADLE_VERSION -DandroidGradle.version=NOT_AVAILABLE
+fi
 
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-rc-2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/integrationTests/src/test/java/org/sonarqube/gradle/AbstractGradleIT.java
+++ b/integrationTests/src/test/java/org/sonarqube/gradle/AbstractGradleIT.java
@@ -48,7 +48,13 @@ public abstract class AbstractGradleIT {
   static {
     try {
       gradleVersion = new Semver(IOUtils.toString(AbstractGradleIT.class.getResource("/gradleversion.txt"), StandardCharsets.UTF_8), SemverType.LOOSE);
-      androidGradleVersion = new Semver(IOUtils.toString(AbstractGradleIT.class.getResource("/androidgradleversion.txt"), StandardCharsets.UTF_8), SemverType.LOOSE);
+
+      String androidGradleVersionString = IOUtils.toString(AbstractGradleIT.class.getResource("/androidgradleversion.txt"), StandardCharsets.UTF_8);
+      if ("NOT_AVAILABLE".equals(androidGradleVersionString)) {
+        androidGradleVersion = null;
+      } else {
+        androidGradleVersion = new Semver(androidGradleVersionString, SemverType.LOOSE);
+      }
     } catch (IOException e) {
       throw new IllegalStateException(e);
     }

--- a/integrationTests/src/test/java/org/sonarqube/gradle/AndroidTest.java
+++ b/integrationTests/src/test/java/org/sonarqube/gradle/AndroidTest.java
@@ -29,14 +29,21 @@ import java.util.List;
 import java.util.Properties;
 import org.junit.Assume;
 import org.junit.Test;
+import org.junit.BeforeClass;
 
 import static java.util.Arrays.stream;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.junit.Assume.assumeTrue;
+import static org.junit.Assume.assumeNotNull;
 
 public class AndroidTest extends AbstractGradleIT {
+
+  @BeforeClass
+  public static void beforeAll() {
+    assumeNotNull(getAndroidGradleVersion());
+  }
 
   private boolean shouldExpectOldJavaBinariesDir() {
     return getAndroidGradleVersion().isLowerThan("3.5.0");


### PR DESCRIPTION
1. I've tried introducing some test for SonarPropertyComputer (doesn't have any test yet) and I failed. Since we are relying heavily on reflection and Gradle version - it is not so easy to test.
2. Android Gradle Plugin 7.x is not compatible with Gradle 8. Android Gradle Plugin 8.x is not released yet. 
https://mvnrepository.com/artifact/com.android.tools.build/gradle?repo=google

So if we merge this PR in its current form we would need to add a ticket to bump AGP when they release it (and add IT for it).