### PR TITLE
Configure tasks on demand

### DIFF
--- a/src/main/java/org/sonarqube/gradle/SonarPropertyComputer.java
+++ b/src/main/java/org/sonarqube/gradle/SonarPropertyComputer.java
@@ -192,7 +192,7 @@ public class SonarPropertyComputer {
   }
 
   private static void configureSourceEncoding(Project project, final Map<String, Object> properties) {
-    project.getTasks().withType(JavaCompile.class, compile -> {
+    project.getTasks().withType(JavaCompile.class).configureEach(compile -> {
       String encoding = compile.getOptions().getEncoding();
       if (encoding != null) {
         properties.put("sonar.sourceEncoding", encoding);
@@ -257,7 +257,7 @@ public class SonarPropertyComputer {
   }
 
   private static void configureJaCoCoCoverageReport(final Test testTask, final boolean addForGroovy, Project project, final Map<String, Object> properties) {
-    project.getTasks().withType(JacocoReport.class, jacocoReportTask -> {
+    project.getTasks().withType(JacocoReport.class).configureEach(jacocoReportTask -> {
       SingleFileReport xmlReport = jacocoReportTask.getReports().getXml();
       File reportDestination = getDestination(xmlReport);
       if (isReportEnabled(xmlReport) && reportDestination != null && reportDestination.exists()) {


### PR DESCRIPTION
As per https://melix.github.io/blog/2022/05/gradle-laziness.html, we'll try to avoid eagerly configuring the task unless the user needs it.
Currently the sonarqube gradle plugin does not support gradle 8. Instead of disabling the relevant tasks, we have to remove the plugin as the tasks are eagerly configured.
```
java.lang.NoSuchMethodError: 'org.gradle.api.provider.Provider org.gradle.api.reporting.Report.getOutputLocation()'
	at org.sonarqube.gradle.SonarPropertyComputer.getDestination(SonarPropertyComputer.java:423)
	at org.sonarqube.gradle.SonarPropertyComputer.configureTestReports(SonarPropertyComputer.java:286)
	at org.sonarqube.gradle.SonarPropertyComputer.extractTestProperties(SonarPropertyComputer.java:255)
	at org.sonarqube.gradle.SonarPropertyComputer.lambda$configureForJava$5(SonarPropertyComputer.java:226)
	at org.gradle.api.internal.collections.CollectionFilter$1.execute(CollectionFilter.java:59)
```