### PR TITLE
NO-JIRA moving from release candidate to released version of gradle

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -144,7 +144,7 @@ gradle_qa_java17_task:
     matrix:
       - GRADLE_VERSION: 7.4.1
         ANDROID_GRADLE_VERSION: 7.1.0
-      - GRADLE_VERSION: 8.0-rc-3
+      - GRADLE_VERSION: 8.0
   gradle_cache:
     folder: ~/.gradle/caches
   script:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The failure of the QA in unexpected. I will look into that.