### PR TITLE
Change task name

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -125,7 +125,7 @@ tasks.jacocoTestReport {
 
 apply(from = "sonarqube-build.gradle.kts")
 
-tasks.getByName("sonarqube").dependsOn(tasks.jacocoTestReport)
+tasks.getByName("sonar").dependsOn(tasks.jacocoTestReport)
 
 val bomFile = layout.buildDirectory.file("reports/bom.json")
 tasks.cyclonedxBom {


### PR DESCRIPTION
Fixes an issue where we no longer generated coverage data because the upstream build script changed task from `sonarqube` to `sonar`.