### PR TITLE
SONARGRADL-132 Rename parameter `sonar.skipCompile` to `sonar.gradle.skipCompile`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.sonarsource.scanner.gradle
-version=4.5-SNAPSHOT
+version=4.4.1-SNAPSHOT
 description=Gradle plugin to help analyzing projects with SonarQube
 projectTitle=SonarQube Scanner for Gradle
 kotlinVersion=1.8.20

--- a/integrationTests/pom.xml
+++ b/integrationTests/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <groupId>org.sonarsource.scanner.gradle</groupId>
   <artifactId>it-gradle</artifactId>
-  <version>4.5-SNAPSHOT</version>
+  <version>4.4.1-SNAPSHOT</version>
   <name>Gradle Plugin :: Integration Tests</name>
   <inceptionYear>2015</inceptionYear>
 

--- a/src/main/java/org/sonarqube/gradle/SonarQubePlugin.java
+++ b/src/main/java/org/sonarqube/gradle/SonarQubePlugin.java
@@ -110,7 +110,7 @@ public class SonarQubePlugin implements Plugin<Project> {
       sonarTask.setProperties(conventionProvider);
     }
 
-    boolean skipImplicitCompilation = Boolean.getBoolean("sonar.skipCompile");
+    boolean skipImplicitCompilation = Boolean.getBoolean("sonar.gradle.skipCompile");
 
     if (skipImplicitCompilation) {
       sonarTask.mustRunAfter(getJavaCompileTasks(project));
@@ -118,7 +118,7 @@ public class SonarQubePlugin implements Plugin<Project> {
     } else {
       LOGGER.warn(
               "The '{}' task depends on compile tasks. This behavior is now deprecated and will be removed in version 5.x. " +
-                      "To avoid implicit compilation, set property 'sonar.skipCompile' to 'true' " +
+                      "To avoid implicit compilation, set property 'sonar.gradle.skipCompile' to 'true' " +
                       "and make sure your project is compiled, before analysis has started.",
               sonarTask.getName()
       );

--- a/src/test/groovy/org/sonarqube/gradle/FunctionalTests.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/FunctionalTests.groovy
@@ -340,11 +340,10 @@ class FunctionalTests extends Specification {
                 .withArguments('sonar', '-Dsonar.scanner.dumpToFile=' + outFile.toAbsolutePath())
                 .withPluginClasspath()
                 .build()
-
         then:
         result.task(":sonar").outcome == SUCCESS
 
-        result.output.contains("The 'sonar' task depends on compile tasks. This behavior is now deprecated and will be removed in version 5.x. To avoid implicit compilation, set property 'sonar.skipCompile' to 'true' and make sure your project is compiled, before analysis has started.")
+        result.output.contains("The 'sonar' task depends on compile tasks. This behavior is now deprecated and will be removed in version 5.x. To avoid implicit compilation, set property 'sonar.gradle.skipCompile' to 'true' and make sure your project is compiled, before analysis has started.")
     }
 
     def "do not warn if implicit compilation is disabled"() {
@@ -360,16 +359,16 @@ class FunctionalTests extends Specification {
         def result = GradleRunner.create()
                 .withProjectDir(testProjectDir.toFile())
                 .forwardOutput()
-                .withArguments('sonar', '-Dsonar.skipCompile=true', '-Dsonar.scanner.dumpToFile=' + outFile.toAbsolutePath())
+                .withArguments('sonar', '-Dsonar.gradle.skipCompile=true', '-Dsonar.scanner.dumpToFile=' + outFile.toAbsolutePath())
                 .withPluginClasspath()
                 .build()
 
         then:
         result.task(":sonar").outcome == SUCCESS
-        !result.output.contains("The 'sonar' task depends on compile tasks. This behavior is now deprecated and will be removed in version 5.x. To avoid implicit compilation, set property 'sonar.skipCompile' to 'true' and make sure your project is compiled, before analysis has started.")
+        !result.output.contains("The 'sonar' task depends on compile tasks. This behavior is now deprecated and will be removed in version 5.x. To avoid implicit compilation, set property 'sonar.gradle.skipCompile' to 'true' and make sure your project is compiled, before analysis has started.")
     }
 
-    def "warn if `sonar.skipCompile` is set to false"() {
+    def "warn if `sonar.gradle.skipCompile` is set to false"() {
         given:
         settingsFile << "rootProject.name = 'java-task-toolchains'"
         buildFile << """
@@ -382,13 +381,13 @@ class FunctionalTests extends Specification {
         def result = GradleRunner.create()
                 .withProjectDir(testProjectDir.toFile())
                 .forwardOutput()
-                .withArguments('sonar', '-Dsonar.skipCompile=false', '-Dsonar.scanner.dumpToFile=' + outFile.toAbsolutePath())
+                .withArguments('sonar', '-Dsonar.gradle.skipCompile=false', '-Dsonar.scanner.dumpToFile=' + outFile.toAbsolutePath())
                 .withPluginClasspath()
                 .build()
 
         then:
         result.task(":sonar").outcome == SUCCESS
 
-        result.output.contains("The 'sonar' task depends on compile tasks. This behavior is now deprecated and will be removed in version 5.x. To avoid implicit compilation, set property 'sonar.skipCompile' to 'true' and make sure your project is compiled, before analysis has started.")
+        result.output.contains("The 'sonar' task depends on compile tasks. This behavior is now deprecated and will be removed in version 5.x. To avoid implicit compilation, set property 'sonar.gradle.skipCompile' to 'true' and make sure your project is compiled, before analysis has started.")
     }
 }

--- a/src/test/groovy/org/sonarqube/gradle/SonarQubePluginTest.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/SonarQubePluginTest.groovy
@@ -833,8 +833,8 @@ class SonarQubePluginTest extends Specification {
     mustRunAfterTasks(sonarTask) == ["test"]
   }
 
-  def "Do not add implicit compile dependencies if 'sonar.skipCompile' property is true"() {
-    System.setProperty("sonar.skipCompile", "true")
+  def "Do not add implicit compile dependencies if 'sonar.gradle.skipCompile' property is true"() {
+    System.setProperty("sonar.gradle.skipCompile", "true")
     def rootProject = ProjectBuilder.builder().withName("root").build()
     rootProject.pluginManager.apply(JavaPlugin)
 
@@ -849,8 +849,8 @@ class SonarQubePluginTest extends Specification {
     mustRunAfterTasks(sonarTask).containsAll(["test", "compileJava", "compileTestJava"])
   }
 
-  def "Add implicit compile dependencies if 'sonar.skipCompile' property is false"() {
-    System.setProperty("sonar.skipCompile", "false")
+  def "Add implicit compile dependencies if 'sonar.gradle.skipCompile' property is false"() {
+    System.setProperty("sonar.gradle.skipCompile", "false")
     def rootProject = ProjectBuilder.builder().withName("root").build()
     rootProject.pluginManager.apply(JavaPlugin)
 


### PR DESCRIPTION
Rename the parameter so that its name carries its Gradle specificity. This should make it clearer that this parameter is not meant to be supported by other scanners.