### PR TITLE
SCANGRADLE-152 Fix issue with "sonar.tests" in child modules

### DIFF
--- a/src/main/java/org/sonarqube/gradle/SonarPropertyComputer.java
+++ b/src/main/java/org/sonarqube/gradle/SonarPropertyComputer.java
@@ -136,8 +136,9 @@ public class SonarPropertyComputer {
 
     overrideWithUserDefinedProperties(project, rawProperties);
 
-    // This is required if "sonar.sources" are neither found nor defined by user
+    // This is required if "sonar.sources" or "sonar.tests" are neither found nor defined by user; possible undesired behaviors due to the copy of those properties from the parent
     rawProperties.putIfAbsent(ScanProperties.PROJECT_SOURCE_DIRS, "");
+    rawProperties.putIfAbsent(ScanProperties.PROJECT_TEST_DIRS, "");
 
     if (project.equals(targetProject)) {
       rawProperties.putIfAbsent("sonar.projectKey", computeProjectKey());

--- a/src/main/java/org/sonarqube/gradle/SonarPropertyComputer.java
+++ b/src/main/java/org/sonarqube/gradle/SonarPropertyComputer.java
@@ -136,7 +136,8 @@ public class SonarPropertyComputer {
 
     overrideWithUserDefinedProperties(project, rawProperties);
 
-    // This is required if "sonar.sources" or "sonar.tests" are neither found nor defined by user; possible undesired behaviors due to the copy of those properties from the parent
+    // These empty assignments are required because modules with no `sonar.sources` or `sonar.tests` value inherit the value from their parent module.
+    // This can eventually lead to a double indexing issue in the scanner-engine.
     rawProperties.putIfAbsent(ScanProperties.PROJECT_SOURCE_DIRS, "");
     rawProperties.putIfAbsent(ScanProperties.PROJECT_TEST_DIRS, "");
 

--- a/src/test/groovy/org/sonarqube/gradle/GradleKtsTests.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/GradleKtsTests.groovy
@@ -83,7 +83,7 @@ class GradleKtsTests extends Specification {
 
         then:
         props["sonar.sources"] == buildFile.toRealPath().toString()
-        !props.containsKey("sonar.tests")
+        props["sonar.tests"] == ""
     }
 
     def "add only settings file to sources when only settings file is in kotlin dsl"() {
@@ -104,7 +104,7 @@ class GradleKtsTests extends Specification {
 
         then:
         props["sonar.sources"] == settingsFile.toRealPath().toString()
-        !props.containsKey("sonar.tests")
+        props["sonar.tests"] == ""
     }
 
     def "add only build file to sources when no settings found"() {
@@ -124,7 +124,7 @@ class GradleKtsTests extends Specification {
 
         then:
         props["sonar.sources"] == buildFile.toRealPath().toString()
-        !props.containsKey("sonar.tests")
+        props["sonar.tests"] == ""
     }
 
     def "add nothing to sources when Groovy dsl is used"() {
@@ -145,7 +145,7 @@ class GradleKtsTests extends Specification {
 
         then:
         props["sonar.sources"] == ""
-        !props.containsKey("sonar.tests")
+        props["sonar.tests"] == ""
     }
 
     def "add nothing to sources when Groovy dsl is used and no settings"() {
@@ -165,7 +165,7 @@ class GradleKtsTests extends Specification {
 
         then:
         props["sonar.sources"] == ""
-        !props.containsKey("sonar.tests")
+        props["sonar.tests"] == ""
     }
 
     def "add .gradle.kts files to sources only once"() {

--- a/src/test/groovy/org/sonarqube/gradle/SonarQubePluginTest.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/SonarQubePluginTest.groovy
@@ -485,7 +485,7 @@ class SonarQubePluginTest extends Specification {
     def properties = parentSonarTask().properties.get()
 
     then:
-    !properties.containsKey("sonar.tests")
+    properties["sonar.tests"].isEmpty()
     !properties.containsKey("sonar.surefire.reportsPath")
     !properties.containsKey("sonar.junit.reportsPath")
   }


### PR DESCRIPTION
Child modules copy the "sonar.tests" property from the parent when it is not defined. This behavior is encoded in the scanner engine, and it breaks the logic defined in [SCANGRADLE-152](https://sonarsource.atlassian.net/browse/SCANGRADLE-152) causing doubled indexing.

[SCANGRADLE-152]: https://sonarsource.atlassian.net/browse/SCANGRADLE-152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ