### PR TITLE
Rollback to old promote task script

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -158,7 +158,10 @@ promote_task:
     memory: 2G
   env:
     ARTIFACTORY_PROMOTE_ACCESS_TOKEN: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promoter access_token]
-  script: cirrus_promote_gradle
+  script:
+    - source cirrus-env PROMOTE
+    - cirrus_jfrog_promote multi
+    - burgr-notify-promotion
 
 release_to_plugin_portal_task:
   only_if: $CIRRUS_PRERELEASE != "true" && $CIRRUS_RELEASE != ""


### PR DESCRIPTION
Reverted to fix a problem where the task could not push the promoted artifact to repox because of missing credentials