### PR TITLE
Lazily register sonar and sonarqube tasks

### DIFF
--- a/src/main/java/org/sonarqube/gradle/SonarQubePlugin.java
+++ b/src/main/java/org/sonarqube/gradle/SonarQubePlugin.java
@@ -76,16 +76,17 @@ public class SonarQubePlugin implements Plugin<Project> {
       addExtensions(project, SonarExtension.SONAR_DEPRECATED_EXTENSION_NAME, actionBroadcastMap);
       LOGGER.debug("Adding '{}' task to '{}'", SonarExtension.SONAR_TASK_NAME, project);
 
-      SonarTask sonarqubeTask = project.getTasks().create(SonarExtension.SONAR_DEPRECATED_TASK_NAME, SonarTask.class);
-      sonarqubeTask.setDescription("Analyzes " + project + " and its subprojects with Sonar. This task is deprecated. Use 'sonar' instead.");
-      sonarqubeTask.setGroup(JavaBasePlugin.VERIFICATION_GROUP);
+      project.getTasks().register(SonarExtension.SONAR_DEPRECATED_TASK_NAME, SonarTask.class, task -> {
+        task.setDescription("Analyzes " + project + " and its subprojects with Sonar. This task is deprecated. Use 'sonar' instead.");
+        task.setGroup(JavaBasePlugin.VERIFICATION_GROUP);
+        configureTask(task, project, actionBroadcastMap);
+      });
 
-      SonarTask sonarTask = project.getTasks().create(SonarExtension.SONAR_TASK_NAME, SonarTask.class);
-      sonarTask.setDescription("Analyzes " + project + " and its subprojects with Sonar.");
-      sonarTask.setGroup(JavaBasePlugin.VERIFICATION_GROUP);
-
-      configureTask(sonarqubeTask, project, actionBroadcastMap);
-      configureTask(sonarTask, project, actionBroadcastMap);
+      project.getTasks().register(SonarExtension.SONAR_TASK_NAME, SonarTask.class, task -> {
+        task.setDescription("Analyzes " + project + " and its subprojects with Sonar.");
+        task.setGroup(JavaBasePlugin.VERIFICATION_GROUP);
+        configureTask(task, project, actionBroadcastMap);
+      });
     }
   }
 


### PR DESCRIPTION
Replace eager task registration via `TaskContainer.create()` with lazy registration via `TaskContainer.register()`.

Motivation: analyzing a build scan, I've noticed that my build had 2 tasks created immediately. Those turned out to be  `sonar` and `sonarqube`.

![CleanShot 2024-07-13 at 00 31 05@2x](https://github.com/user-attachments/assets/95adb9dc-8d40-4902-9874-dcefbd7f8119)

It would be great to avoid creating those tasks if SonarScanner isn't executed.