### PR TITLE
Make value of SonarProperties#property nullable

### DIFF
--- a/src/main/java/org/sonarqube/gradle/SonarProperties.java
+++ b/src/main/java/org/sonarqube/gradle/SonarProperties.java
@@ -19,6 +19,7 @@
  */
 package org.sonarqube.gradle;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 /**
@@ -45,7 +46,7 @@ public class SonarProperties {
    * @param key the key of the property to be added
    * @param value the value of the property to be added
    */
-  public void property(String key, Object value) {
+  public void property(String key, @Nullable Object value) {
     properties.put(key, value);
   }
 


### PR DESCRIPTION
I'm porting a Groovy DSL build to Kotlin DSL.

Before I did things like
```groovy
property('foo', [...] ?: null)
```
to override `foo` and either set it to some value or unset it otherwise.

In Kotlin DSL you cannot do
```kotlin
property("foo", listOf(...).takeIf { it.isNotEmpty() })
```
currently due to the `@ParametersAreNonnullByDefault` in the `package-info.java` and Kotlin respecting that, so having the value parameter non-nullable.
Work-around is to use
```kotlin
properties["foo"] = listOf(...).takeIf { it.isNotEmpty() }
```
or
```kotlin
listOf(...).also { if (it.isNotEmpty()) property("foo", it) else properties.remove("foo") }
``` 

This PR makes the value parameter nullable, so you can also use the first Kotlin snippet above.