### PR TITLE
SCANGRADLE-163 enable gradle version 7.5.1 in ITs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -122,8 +122,8 @@ gradle_qa_task:
       - GRADLE_VERSION: 8.3
       - GRADLE_VERSION: 8.0
       - GRADLE_VERSION: 7.6.4
-#- GRADLE_VERSION: 7.5.1
-#        ANDROID_GRADLE_VERSION: 7.1.0
+      - GRADLE_VERSION: 7.5.1
+        ANDROID_GRADLE_VERSION: 7.1.0
   script:
     - ./cirrus/cirrus-qa.sh
 


### PR DESCRIPTION
[SCANGRADLE-178](https://sonarsource.atlassian.net/browse/SCANGRADLE-178)



[SCANGRADLE-178]: https://sonarsource.atlassian.net/browse/SCANGRADLE-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ