### PR TITLE
SCANGRADLE-185 Remove subnet-related config from .cirrus.yml

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,7 +28,6 @@ container_definition_11: &CONTAINER_DEFINITION_11
   builder_role: cirrus-builder
   builder_image: docker-builder-v*
   builder_instance_type: t2.small
-  builder_subnet_id: ${CIRRUS_AWS_SUBNET}
   region: eu-central-1
   namespace: default
 
@@ -40,7 +39,6 @@ container_definition_17: &CONTAINER_DEFINITION_17
   builder_role: cirrus-builder
   builder_image: docker-builder-v*
   builder_instance_type: t2.small
-  builder_subnet_id: ${CIRRUS_AWS_SUBNET}
   region: eu-central-1
   namespace: default
 


### PR DESCRIPTION
[SCANGRADLE-185](https://sonarsource.atlassian.net/browse/SCANGRADLE-185)

cirrus-modules@v3 provides this configuration and it should not be configured in the project itself.



[SCANGRADLE-185]: https://sonarsource.atlassian.net/browse/SCANGRADLE-185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ