### PR TITLE
Fix gradle project convention deprecation

### DIFF
--- a/src/main/java/org/sonarqube/gradle/SonarPropertyComputer.java
+++ b/src/main/java/org/sonarqube/gradle/SonarPropertyComputer.java
@@ -56,6 +56,7 @@ import org.gradle.api.plugins.GroovyPlugin;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.reporting.Report;
@@ -430,15 +431,15 @@ public class SonarPropertyComputer {
   }
 
   private static void configureSourceDirsAndJavaClasspath(Project project, Map<String, Object> properties, boolean addForGroovy) {
-    JavaPluginConvention javaPluginConvention = new DslObject(project).getConvention().getPlugin(JavaPluginConvention.class);
+    JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
 
-    SourceSet main = javaPluginConvention.getSourceSets().getAt("main");
+    SourceSet main = javaPluginExtension.getSourceSets().getAt("main");
     Collection<File> sourceDirectories = getJavaSourceFiles(main);
     if (sourceDirectories != null) {
       SonarUtils.appendSourcesProp(properties, sourceDirectories, false);
     }
 
-    SourceSet test = javaPluginConvention.getSourceSets().getAt("test");
+    SourceSet test = javaPluginExtension.getSourceSets().getAt("test");
     Collection<File> testDirectories = getJavaSourceFiles(test);
     if (testDirectories != null) {
       SonarUtils.appendSourcesProp(properties, testDirectories, true);
@@ -453,14 +454,14 @@ public class SonarPropertyComputer {
   }
 
   private static void configureJavaClasspath(Project project, Map<String, Object> properties, boolean addForGroovy) {
-    JavaPluginConvention javaPluginConvention = new DslObject(project).getConvention().getPlugin(JavaPluginConvention.class);
+    JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
 
-    SourceSet main = javaPluginConvention.getSourceSets().getAt("main");
+    SourceSet main = javaPluginExtension.getSourceSets().getAt("main");
     Collection<File> mainClassDirs = getJavaOutputDirs(main);
     Collection<File> mainLibraries = getJavaLibraries(main);
     setMainClasspathProps(properties, mainClassDirs, mainLibraries, addForGroovy);
 
-    SourceSet test = javaPluginConvention.getSourceSets().getAt("test");
+    SourceSet test = javaPluginExtension.getSourceSets().getAt("test");
     Collection<File> testClassDirs = getJavaOutputDirs(test);
     Collection<File> testLibraries = getJavaLibraries(test);
     setTestClasspathProps(properties, testClassDirs, testLibraries);


### PR DESCRIPTION
* this is deprecated since gradle 7.1 and will be removed with gradle 9 see [here](https://docs.gradle.org/7.1/userguide/upgrading_version_7.html#changes_7.1)
* this holds my company from using `org.gradle.warning.mode=fail`

I see a TODO [here](https://github.com/SonarSource/sonar-scanner-gradle/blob/master/src/main/java/org/sonarqube/gradle/SonarPropertyComputer.java#L376) which leads me to belive you might still want to support gradle < 7.1.
Edit: This is not true (Couldn't find out if that still holds true, if so this can't be merged.)
Otherwise I'm happy create additional PRs to fix the two TODOs associated with backwards compatibility.
If you create an Issue I'm happy to update the PR and commit message to reflect it.

Note:
As far as I can tell File SonarPropertyComputer has some lines that don't comply with your formatting settings from [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style).
I could create an additional PR to fix that if thats ok with you.
