### PR TITLE
SCANGRADLE-192 External contributor can’t build sonar-scanner-gradle plugin

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -89,8 +89,12 @@ validate_external_contributor_build_task:
     folder: ~/.gradle/caches
   maven_cache:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository
-  script:
-    - unset ARTIFACTORY_URL && unset ARTIFACTORY_PRIVATE_USERNAME && unset ARTIFACTORY_PRIVATE_PASSWORD && unset ARTIFACTORY_ACCESS_TOKEN && ./gradlew clean build
+  script: |
+    unset ARTIFACTORY_URL && \
+    unset ARTIFACTORY_PRIVATE_USERNAME && \
+    unset ARTIFACTORY_PRIVATE_PASSWORD && \
+    unset ARTIFACTORY_ACCESS_TOKEN && \
+    ./gradlew --refresh-dependencies clean assemble testClasses
   on_failure:
     reports_artifacts:
       path: "**/build/reports/**/*"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -78,6 +78,26 @@ build_task:
       path: "**/test-results/**/*.xml"
       format: junit
 
+validate_external_contributor_build_task:
+  depends_on:
+    - build
+  eks_container:
+    <<: *CONTAINER_DEFINITION_17
+    cpu: 1.5
+    memory: 4G
+  gradle_cache:
+    folder: ~/.gradle/caches
+  maven_cache:
+    folder: ${CIRRUS_WORKING_DIR}/.m2/repository
+  script:
+    - unset ARTIFACTORY_URL && unset ARTIFACTORY_PRIVATE_USERNAME && unset ARTIFACTORY_PRIVATE_PASSWORD && unset ARTIFACTORY_ACCESS_TOKEN && ./gradlew clean build
+  on_failure:
+    reports_artifacts:
+      path: "**/build/reports/**/*"
+    junit_artifacts:
+      path: "**/test-results/**/*.xml"
+      format: junit
+
 mend_scan_task:
   <<: *SETUP_GRADLE_CACHE
   depends_on:
@@ -149,6 +169,7 @@ gradle_qa_java11_task:
 promote_task:
   depends_on:
     - build
+    - validate_external_contributor_build
     - gradle_qa
     - gradle_qa_java11
   <<: *ONLY_SONARSOURCE_QA

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,25 +47,25 @@ if (project.version.toString().endsWith("-SNAPSHOT") && buildNumber != null) {
 }
 
 repositories {
+    mavenLocal()
     maven {
         url = uri("https://maven.google.com")
     }
-
-    val repository = if (project.hasProperty("qa")) "sonarsource-qa" else "sonarsource"
-    maven {
-        url = uri("https://repox.jfrog.io/repox/${repository}")
-
-        // The environment variables ARTIFACTORY_PRIVATE_USERNAME and ARTIFACTORY_PRIVATE_PASSWORD are used on QA env (Jenkins)
-        // On local box, please add artifactoryUsername and artifactoryPassword to ~/.gradle/gradle.properties
-        val artifactoryUsername = System.getenv("ARTIFACTORY_PRIVATE_USERNAME") ?: project.findProperty("artifactoryUsername") ?: ""
-        val artifactoryPassword = System.getenv("ARTIFACTORY_PRIVATE_PASSWORD") ?: project.findProperty("artifactoryPassword") ?: ""
-
-        if (artifactoryUsername is String && artifactoryUsername.isNotEmpty() && artifactoryPassword is String && artifactoryPassword.isNotEmpty()) {
+    // The environment variables ARTIFACTORY_PRIVATE_USERNAME and ARTIFACTORY_PRIVATE_PASSWORD are used on CI env
+    // If you have access to "repox.jfrog.io" you can add artifactoryUsername and artifactoryPassword to ~/.gradle/gradle.properties
+    val artifactoryUsername = System.getenv("ARTIFACTORY_PRIVATE_USERNAME") ?: project.findProperty("artifactoryUsername") ?: ""
+    val artifactoryPassword = System.getenv("ARTIFACTORY_PRIVATE_PASSWORD") ?: project.findProperty("artifactoryPassword") ?: ""
+    if (artifactoryUsername is String && artifactoryUsername.isNotEmpty() && artifactoryPassword is String && artifactoryPassword.isNotEmpty()) {
+        maven {
+            val repository = if (project.hasProperty("qa")) "sonarsource-qa" else "sonarsource"
+            url = uri("https://repox.jfrog.io/repox/${repository}")
             credentials {
                 username = artifactoryUsername
                 password = artifactoryPassword
             }
         }
+    } else {
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
[SCANGRADLE-192](https://sonarsource.atlassian.net/browse/SCANGRADLE-192)



[SCANGRADLE-192]: https://sonarsource.atlassian.net/browse/SCANGRADLE-192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ