### PR TITLE
SCANGRADLE-209 Log the SonarQube Cloud Region

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,7 +70,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.sonarsource.scanner.lib:sonar-scanner-java-library:3.3.0.442")
+    implementation("org.sonarsource.scanner.lib:sonar-scanner-java-library:3.3.1.450")
     compileOnly("com.google.code.findbugs:jsr305:3.0.2")
     compileOnly("com.android.tools.build:gradle:8.1.1")
     compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.21")


### PR DESCRIPTION
[SCANGRADLE-209](https://sonarsource.atlassian.net/browse/SCANGRADLE-209)

Logging is done by the most recent version of the sonar-scanner-java-library.


[SCANGRADLE-209]: https://sonarsource.atlassian.net/browse/SCANGRADLE-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ