### PR TITLE
SCANGRADLE-216 Update orchestrator dependency to version 5.5

### DIFF
--- a/integrationTests/pom.xml
+++ b/integrationTests/pom.xml
@@ -61,7 +61,13 @@
     <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
       <artifactId>sonar-orchestrator</artifactId>
-      <version>3.42.0.312</version>
+      <version>5.5.0.2535</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.sonarsource.orchestrator</groupId>
+      <artifactId>sonar-orchestrator-junit4</artifactId>
+      <version>5.5.0.2535</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/integrationTests/src/test/java/org/sonarqube/gradle/BootstrapTest.java
+++ b/integrationTests/src/test/java/org/sonarqube/gradle/BootstrapTest.java
@@ -19,7 +19,7 @@
  */
 package org.sonarqube.gradle;
 
-import com.sonar.orchestrator.Orchestrator;
+import com.sonar.orchestrator.junit4.OrchestratorRule;
 import com.sonar.orchestrator.locator.FileLocation;
 import com.sonar.orchestrator.locator.MavenLocation;
 import java.io.File;
@@ -44,13 +44,13 @@ import static org.junit.Assume.assumeTrue;
 public class BootstrapTest extends AbstractGradleIT {
 
   @ClassRule
-  public static final Orchestrator ORCHESTRATOR;
+  public static final OrchestratorRule ORCHESTRATOR;
 
   static {
     if (getJavaVersion() < 17) {
       ORCHESTRATOR = null;
     } else {
-      ORCHESTRATOR = Orchestrator.builderEnv()
+      ORCHESTRATOR = OrchestratorRule.builderEnv()
         .setSonarVersion("LATEST_RELEASE")
         .useDefaultAdminCredentialsForBuilds(true)
         .addPlugin(MavenLocation.of("org.sonarsource.java", "sonar-java-plugin", "LATEST_RELEASE"))


### PR DESCRIPTION
[SCANGRADLE-216](https://sonarsource.atlassian.net/browse/SCANGRADLE-216)


This is to avoid polluting telemetry data with integration tests.

[SCANGRADLE-216]: https://sonarsource.atlassian.net/browse/SCANGRADLE-216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ