### PR TITLE
SCANGRADLE-227 Fix cirrus-ci depends_on error

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -263,7 +263,7 @@ release_plugin_to_repox_task:
 release_plugin_to_gradle_plugin_portal_task:
   only_if: $CIRRUS_PRERELEASE != "true" && $CIRRUS_RELEASE != "" && $CIRRUS_TAG != ""
   depends_on:
-    - release_plugin_to_repox_task
+    - release_plugin_to_repox
   stateful: 'true'
   eks_container:
     <<: *CONTAINER_DEFINITION_17


### PR DESCRIPTION
[SCANGRADLE-227](https://sonarsource.atlassian.net/browse/SCANGRADLE-227)



[SCANGRADLE-227]: https://sonarsource.atlassian.net/browse/SCANGRADLE-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ