### PR TITLE
SCANGRADLE-230 add a new paragraph to the readme about gradle metadata validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ When you update a dependency’s checksum in the gradle/verification-metadata.xm
 First, identify the dependency updated in the file and copy its sha256 checksum. 
 Next, search for the dependency on another package repositories. For instance on [Maven Central](https://central.sonatype.com), you can use the query `checksum:new-dependency-sha256` to find a specific dependency.
 
-
 ### How the plugin works
 When the plugin is applied to a project, it will add to that project the Sonar task. It will also add to the project and all its subprojects the Sonar extension.
 For multi-module projects, the plugin will only apply to the first project where it gets called. The goal is to allow the usage of `allprojects {}`, for example.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ And delete in the `verification-metadata.xml` the versions that we don't use any
 But do not delete all unused versions for dependencies with a dynamic version set to `latest.release` (like `org.sonarsource.scanner.gradle:sonarqube-gradle-plugin`), 
 because Gradle cache the version resolution for 24 hours, so for those dependencies, we also need to keep the before last version.
 
+When you update a dependency’s checksum in the gradle/verification-metadata.xml file, you validate the change by comparing the sha256 value from Artifactory with the one listed on another package repositories like maven central. 
+First, identify the dependency updated in the file and copy its sha256 checksum. 
+Next, search for the dependency on another package repositories. For instance on [Maven Central](https://central.sonatype.com), you can use the query `checksum:new-dependency-sha256` to find a specific dependency.
+
+
 ### How the plugin works
 When the plugin is applied to a project, it will add to that project the Sonar task. It will also add to the project and all its subprojects the Sonar extension.
 For multi-module projects, the plugin will only apply to the first project where it gets called. The goal is to allow the usage of `allprojects {}`, for example.


### PR DESCRIPTION
[SCANGRADLE-230](https://sonarsource.atlassian.net/browse/SCANGRADLE-230)

document the process to validate a new dependency inside the `gradle/verification-metadata.xml` file




[SCANGRADLE-230]: https://sonarsource.atlassian.net/browse/SCANGRADLE-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ