### PR TITLE
SLCORE-1545 Update version of commons-lang dependency

### DIFF
--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -1456,12 +1456,12 @@
             <sha256 value="df8cc1a8387d4ce842363b7209fdc6d35df9763839fd3fcab558a0f83f9d841c" origin="Verified"/>
          </artifact>
       </component>
-      <component group="org.apache.commons" name="commons-lang3" version="3.17.0">
-         <artifact name="commons-lang3-3.17.0.jar">
-            <sha256 value="6ee731df5c8e5a2976a1ca023b6bb320ea8d3539fbe64c8a1d5cb765127c33b4" origin="Verified"/>
+      <component group="org.apache.commons" name="commons-lang3" version="3.18.0">
+         <artifact name="commons-lang3-3.18.0.jar">
+            <sha256 value="4eeeae8d20c078abb64b015ec158add383ac581571cddc45c68f0c9ae0230720" origin="Verified"/>
          </artifact>
-         <artifact name="commons-lang3-3.17.0.pom">
-            <sha256 value="351c6e4940e939b1f330df47f60f13ba383db81ee008181af541f3a2a6d2a56c" origin="Verified"/>
+         <artifact name="commons-lang3-3.18.0.pom">
+            <sha256 value="aa254b373b6f6d46bc9dca86331b072a8ab86eb25ea9921fd439618392e98a16" origin="Verified"/>
          </artifact>
       </component>
       <component group="org.apache.commons" name="commons-lang3" version="3.8.1">


### PR DESCRIPTION
[SLCORE-1545](https://sonarsource.atlassian.net/browse/SLCORE-1545)

This PR bumps **org.apache.commons:commons-lang3** to version `3.18.0` to fix [CVE-2025-48924](https://github.com/advisories/GHSA-j288-q9x7-2f5v).


[SLCORE-1545]: https://sonarsource.atlassian.net/browse/SLCORE-1545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ