### PR TITLE
SCANGRADLE-239 Update sonar-scanner-java-library to 3.4.0.514

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ if (project.version.toString().endsWith("-SNAPSHOT") && buildNumber != null) {
 }
 
 dependencies {
-    implementation("org.sonarsource.scanner.lib:sonar-scanner-java-library:3.3.1.450")
+    implementation("org.sonarsource.scanner.lib:sonar-scanner-java-library:3.4.0.514")
     compileOnly("com.google.code.findbugs:jsr305:3.0.2")
     compileOnly("com.android.tools.build:gradle:8.1.1")
     compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.21")

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,3 +8,4 @@ projectType=application
 org.gradle.daemon=false
 org.gradle.caching=true
 org.gradle.configureondemand=true
+org.gradle.dependency.verification=off

--- a/integrationTests/src/test/java/org/sonarqube/gradle/AbstractGradleIT.java
+++ b/integrationTests/src/test/java/org/sonarqube/gradle/AbstractGradleIT.java
@@ -108,8 +108,7 @@ public abstract class AbstractGradleIT {
       "sonar.scanner.appVersion",
       "sonar.scanner.arch",
       "sonar.scanner.internal.dumpToFile",
-      "sonar.scanner.os",
-      "sonar.scanner.wasEngineCacheHit"));
+      "sonar.scanner.os"));
     Map<String, String> replacementMap = new LinkedHashMap<>();
     replacementMap.put("${parentBaseDir}", Paths.get(absoluteProjectBaseDir).getParent().toString());
     replacementMap.put("${currentWorkingDir}", System.getProperty("user.dir"));

--- a/integrationTests/src/test/java/org/sonarqube/gradle/Gradle9Test.java
+++ b/integrationTests/src/test/java/org/sonarqube/gradle/Gradle9Test.java
@@ -71,7 +71,6 @@ public class Gradle9Test extends AbstractGradleIT {
       entry("sonar.scanner.arch", "<hidden>"),
       entry("sonar.scanner.internal.dumpToFile", "<hidden>"),
       entry("sonar.scanner.os", "<hidden>"),
-      entry("sonar.scanner.wasEngineCacheHit", "false"),
       entry("sonar.sources", "${parentBaseDir}/gradle-9-example/src/main/java," +
         "${parentBaseDir}/gradle-9-example/build.gradle.kts," +
         "${parentBaseDir}/gradle-9-example/settings.gradle.kts"),


### PR DESCRIPTION
[SCANGRADLE-239](https://sonarsource.atlassian.net/browse/SCANGRADLE-239)



[SCANGRADLE-239]: https://sonarsource.atlassian.net/browse/SCANGRADLE-239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ