### PR TITLE
SCANGRADLE-249 Release version 6.3.0.5676 fails with ClassCastException: String cannot be cast to class Collection

### DIFF
--- a/src/main/java/org/sonarqube/gradle/SonarUtils.java
+++ b/src/main/java/org/sonarqube/gradle/SonarUtils.java
@@ -190,9 +190,17 @@ public class SonarUtils {
   }
 
   static void appendProps(Map<String, Object> properties, String key, Iterable<?> valuesToAppend) {
-    properties.putIfAbsent(key, new LinkedHashSet<String>());
-    StreamSupport.stream(valuesToAppend.spliterator(), false)
-      .forEach(((Collection<Object>) properties.get(key))::add);
+    Set<Object> newList = new LinkedHashSet<>();
+    Object previousValue = properties.get(key);
+    if (previousValue instanceof Collection) {
+      newList.addAll((Collection<Object>) previousValue);
+    } else if (previousValue != null) {
+      newList.add(previousValue);
+    }
+    for (Object value : valuesToAppend) {
+      newList.add(value);
+    }
+    properties.put(key, newList);
   }
 
   static void appendSourcesProp(Map<String, Object> properties, Iterable<File> filesToAppend, boolean testSources) {

--- a/src/test/groovy/org/sonarqube/gradle/SonarUtilsGroovyTest.java
+++ b/src/test/groovy/org/sonarqube/gradle/SonarUtilsGroovyTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.sonarqube.gradle.SonarUtils.findProjectFileType;
 import static org.sonarqube.gradle.SonarUtils.isCompatibleWithJavaPluginExtension;
 
-class SonarUtilsTest {
+class SonarUtilsGroovyTest {
 
   @Test
   void get_project_base_dir() {

--- a/src/test/java/org/sonarqube/gradle/SonarUtilsTest.java
+++ b/src/test/java/org/sonarqube/gradle/SonarUtilsTest.java
@@ -1,0 +1,56 @@
+/*
+ * SonarQube Scanner for Gradle
+ * Copyright (C) 2015-2025 SonarSource
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonarqube.gradle;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SonarUtilsTest {
+
+  @Test
+  void append_props_to_without_previous_value() {
+    Map<String, Object> properties = new HashMap<>();
+    SonarUtils.appendProps(properties, "my-key", List.of("a", "b", "c", "d"));
+    assertThat((Collection<Object>) properties.get("my-key")).containsExactly("a", "b", "c", "d");
+  }
+
+  @Test
+  void append_props_to_a_previous_file_value() {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("my-key", new File("a"));
+    SonarUtils.appendProps(properties, "my-key", List.of("b", "c", "d"));
+    assertThat((Collection<Object>) properties.get("my-key")).containsExactly(new File("a"), "b", "c", "d");
+  }
+
+  @Test
+  void append_props_to_a_previous_collection_value() {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put("my-key", List.of("a", "b"));
+    SonarUtils.appendProps(properties, "my-key", List.of("c", "d"));
+    assertThat((Collection<Object>) properties.get("my-key")).containsExactly("a", "b", "c", "d");
+  }
+
+}


### PR DESCRIPTION
[SCANGRADLE-249](https://sonarsource.atlassian.net/browse/SCANGRADLE-249)



[SCANGRADLE-249]: https://sonarsource.atlassian.net/browse/SCANGRADLE-249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ