### PR TITLE
SCANGRADLE-252 ".github" folder should not be added to "sonar.sources" if the user explicitly overrides this property

### DIFF
--- a/src/main/java/org/sonarqube/gradle/SonarPropertyComputer.java
+++ b/src/main/java/org/sonarqube/gradle/SonarPropertyComputer.java
@@ -130,6 +130,7 @@ public class SonarPropertyComputer {
     }
 
     if (isRootProject(project)) {
+      addGithubFolder(project, rawProperties);
       addKotlinBuildScriptsToSources(project, rawProperties);
     }
 
@@ -147,7 +148,6 @@ public class SonarPropertyComputer {
       rawProperties.putIfAbsent("sonar.moduleKey", projectKey + project.getPath());
     }
 
-    addGithubFolder(project, rawProperties);
     convertProperties(rawProperties, prefix, properties);
 
     List<Project> enabledChildProjects = project.getChildProjects().values().stream()


### PR DESCRIPTION
[SCANGRADLE-252](https://sonarsource.atlassian.net/browse/SCANGRADLE-252)



[SCANGRADLE-252]: https://sonarsource.atlassian.net/browse/SCANGRADLE-252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ