### PR TITLE
SCANGRADLE-264 Enable the download of the Gradle sources in IntelliJ

### DIFF
--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -6,6 +6,7 @@
       <trusted-artifacts>
          <trust file=".*-javadoc[.]jar" regex="true"/>
          <trust file=".*-sources[.]jar" regex="true"/>
+         <trust file="^gradle-\d+\.\d+(?:\.\d+)?(?:-(?:rc|milestone)-\d+)?-src\.zip$" regex="true"/>
       </trusted-artifacts>
    </configuration>
    <components>


### PR DESCRIPTION
[SCANGRADLE-264](https://sonarsource.atlassian.net/browse/SCANGRADLE-264)



[SCANGRADLE-264]: https://sonarsource.atlassian.net/browse/SCANGRADLE-264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ