### PR TITLE
SCANGRADLE-247 Remove dangling commas from sonar.java.test.libraries when test class path is empty

### DIFF
--- a/src/main/java/org/sonarqube/gradle/SonarTask.java
+++ b/src/main/java/org/sonarqube/gradle/SonarTask.java
@@ -364,10 +364,12 @@ public class SonarTask extends ConventionTask {
     }
 
     // Append libraries resolved at configuration time
-    if (libraries.isEmpty()) {
-      libraries = resolvedAsAString;
-    } else {
-      libraries += "," + resolvedAsAString;
+    if (!resolvedAsAString.isBlank()) {
+      if (libraries.isEmpty()) {
+        libraries = resolvedAsAString;
+      } else {
+        libraries += "," + resolvedAsAString;
+      }
     }
 
     if (LOGGER.isDebugEnabled()) {

--- a/src/test/java/org/sonarqube/gradle/SonarTaskTest.java
+++ b/src/test/java/org/sonarqube/gradle/SonarTaskTest.java
@@ -176,12 +176,11 @@ class SonarTaskTest {
   }
 
   @Test
-  void resolveSonarJavaTestLibraries_does_not_leave_a_dangling_comma_when_there_are_no_libraries_to_add(@TempDir File tempDir) throws IOException {
+  void resolveSonarJavaTestLibraries_does_not_leave_a_dangling_comma_when_there_are_no_libraries_to_add() {
     Map<String, String> properties = new HashMap<>();
     String binaries = "should-not-be-followed-by-a-comma";
     properties.put("sonar.java.binaries", binaries);
     SonarTask.resolveSonarJavaTestLibraries("", Collections.emptyList(), properties);
-    assertThat(properties.get("sonar.java.test.libraries"))
-            .isEqualTo("should-not-be-followed-by-a-comma");
+    assertThat(properties).containsEntry("sonar.java.test.libraries", "should-not-be-followed-by-a-comma");
   }
 }

--- a/src/test/java/org/sonarqube/gradle/SonarTaskTest.java
+++ b/src/test/java/org/sonarqube/gradle/SonarTaskTest.java
@@ -21,6 +21,7 @@ package org.sonarqube.gradle;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -172,5 +173,15 @@ class SonarTaskTest {
                     "sonar.java.test.libraries", expectedValue
             )
     );
+  }
+
+  @Test
+  void resolveSonarJavaTestLibraries_does_not_leave_a_dangling_comma_when_there_are_no_libraries_to_add(@TempDir File tempDir) throws IOException {
+    Map<String, String> properties = new HashMap<>();
+    String binaries = "should-not-be-followed-by-a-comma";
+    properties.put("sonar.java.binaries", binaries);
+    SonarTask.resolveSonarJavaTestLibraries("", Collections.emptyList(), properties);
+    assertThat(properties.get("sonar.java.test.libraries"))
+            .isEqualTo("should-not-be-followed-by-a-comma");
   }
 }

--- a/src/test/java/org/sonarqube/gradle/SonarTaskTest.java
+++ b/src/test/java/org/sonarqube/gradle/SonarTaskTest.java
@@ -180,7 +180,7 @@ class SonarTaskTest {
     Map<String, String> properties = new HashMap<>();
     String binaries = "should-not-be-followed-by-a-comma";
     properties.put("sonar.java.binaries", binaries);
-    SonarTask.resolveSonarJavaTestLibraries("", Collections.emptyList(), properties);
+    SonarTask.resolveSonarJavaTestLibraries(new ProjectProperties("", true, Collections.emptyList(), Collections.emptyList()), Collections.emptyList(), properties);
     assertThat(properties).containsEntry("sonar.java.test.libraries", "should-not-be-followed-by-a-comma");
   }
 }


### PR DESCRIPTION
[SCANGRADLE-247](https://sonarsource.atlassian.net/browse/SCANGRADLE-247)



[SCANGRADLE-247]: https://sonarsource.atlassian.net/browse/SCANGRADLE-247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ