### PR TITLE
SCANGRADLE-402 Redesign the ProjectProperties class with the builder pattern

### DIFF
--- a/src/main/java/org/sonarqube/gradle/ProjectProperties.java
+++ b/src/main/java/org/sonarqube/gradle/ProjectProperties.java
@@ -94,23 +94,18 @@ public class ProjectProperties {
   }
 
   public static class Builder {
-    private String projectName;
-    private Boolean isRootProject;
-    private List<String> compileClasspath;
-    private List<String> testCompileClasspath;
-    private List<String> mainLibraries;
-    private List<String> testLibraries;
-    private List<String> androidSources;
-    private List<String> androidTests;
+    private final String projectName;
+    private final Boolean isRootProject;
+    private List<String> compileClasspath = List.of();
+    private List<String> testCompileClasspath = List.of();
+    private List<String> mainLibraries = List.of();
+    private List<String> testLibraries = List.of();
+    private List<String> androidSources = List.of();
+    private List<String> androidTests = List.of();
 
-    public Builder projectName(String projectName) {
+    public Builder(String projectName, Boolean isRootProject) {
       this.projectName = projectName;
-      return this;
-    }
-
-    public Builder isRootProject(Boolean isRootProject) {
       this.isRootProject = isRootProject;
-      return this;
     }
 
     public Builder compileClasspath(List<String> compileClasspath) {
@@ -143,7 +138,9 @@ public class ProjectProperties {
       return this;
     }
 
-    public ProjectProperties build() {return new ProjectProperties(this);}
+    public ProjectProperties build() {
+      return new ProjectProperties(this);
+    }
 
   }
 

--- a/src/main/java/org/sonarqube/gradle/ProjectProperties.java
+++ b/src/main/java/org/sonarqube/gradle/ProjectProperties.java
@@ -82,7 +82,7 @@ public class ProjectProperties {
    */
   public final List<String> androidTests;
 
-  public ProjectProperties(Builder builder) {
+  private ProjectProperties(Builder builder) {
     this.projectName = builder.projectName;
     this.isRootProject = builder.isRootProject;
     this.compileClasspath = builder.compileClasspath;

--- a/src/main/java/org/sonarqube/gradle/ProjectProperties.java
+++ b/src/main/java/org/sonarqube/gradle/ProjectProperties.java
@@ -82,35 +82,69 @@ public class ProjectProperties {
    */
   public final List<String> androidTests;
 
-  /**
-   * Creates a new immutable ProjectProperties instance.
-   *
-   * @param projectName          the Gradle project name
-   * @param isRootProject        whether this is the root project
-   * @param compileClasspath     resolved compile classpath as absolute paths
-   * @param testCompileClasspath resolved test compile classpath as absolute paths
-   * @param mainLibraries        filtered main libraries for analysis
-   * @param testLibraries        filtered test libraries for analysis
-   */
-  @SuppressWarnings("java:S107")
-  public ProjectProperties(
-    String projectName,
-    Boolean isRootProject,
-    List<String> compileClasspath,
-    List<String> testCompileClasspath,
-    List<String> mainLibraries,
-    List<String> testLibraries,
-    List<String> androidSources,
-    List<String> androidTests
-  ) {
-    this.projectName = projectName;
-    this.isRootProject = isRootProject;
-    this.compileClasspath = compileClasspath;
-    this.testCompileClasspath = testCompileClasspath;
-    this.mainLibraries = mainLibraries;
-    this.testLibraries = testLibraries;
-    this.androidSources = androidSources;
-    this.androidTests = androidTests;
+  public ProjectProperties(Builder builder) {
+    this.projectName = builder.projectName;
+    this.isRootProject = builder.isRootProject;
+    this.compileClasspath = builder.compileClasspath;
+    this.testCompileClasspath = builder.testCompileClasspath;
+    this.mainLibraries = builder.mainLibraries;
+    this.testLibraries = builder.testLibraries;
+    this.androidSources = builder.androidSources;
+    this.androidTests = builder.androidTests;
+  }
+
+  public static class Builder {
+    private String projectName;
+    private Boolean isRootProject;
+    private List<String> compileClasspath;
+    private List<String> testCompileClasspath;
+    private List<String> mainLibraries;
+    private List<String> testLibraries;
+    private List<String> androidSources;
+    private List<String> androidTests;
+
+    public Builder projectName(String projectName) {
+      this.projectName = projectName;
+      return this;
+    }
+
+    public Builder isRootProject(Boolean isRootProject) {
+      this.isRootProject = isRootProject;
+      return this;
+    }
+
+    public Builder compileClasspath(List<String> compileClasspath) {
+      this.compileClasspath = compileClasspath;
+      return this;
+    }
+
+    public Builder testCompileClasspath(List<String> testCompileClasspath) {
+      this.testCompileClasspath = testCompileClasspath;
+      return this;
+    }
+
+    public Builder mainLibraries(List<String> mainLibraries) {
+      this.mainLibraries = mainLibraries;
+      return this;
+    }
+
+    public Builder testLibraries(List<String> testLibraries) {
+      this.testLibraries = testLibraries;
+      return this;
+    }
+
+    public Builder androidSources(List<String> androidSources) {
+      this.androidSources = androidSources;
+      return this;
+    }
+
+    public Builder androidTests(List<String> androidTests) {
+      this.androidTests = androidTests;
+      return this;
+    }
+
+    public ProjectProperties build() {return new ProjectProperties(this);}
+
   }
 
 }

--- a/src/main/java/org/sonarqube/gradle/SonarResolverTask.java
+++ b/src/main/java/org/sonarqube/gradle/SonarResolverTask.java
@@ -53,7 +53,7 @@ public abstract class SonarResolverTask extends DefaultTask {
   private Provider<Boolean> skipProject;
 
   @Inject
-  public SonarResolverTask() {
+  protected SonarResolverTask() {
     super();
     // Some inputs are annotated with internal, thus grade cannot correctly compute if the task is up to date or not.
     this.getOutputs().upToDateWhen(task -> false);
@@ -189,16 +189,16 @@ public abstract class SonarResolverTask extends DefaultTask {
     Provider<FileCollection> androidTestsProvider = getAndroidTests();
     List<String> androidTestsFilenames = androidTestsProvider == null ? Collections.emptyList() : getAbsolutePaths(androidTestsProvider);
 
-    ProjectProperties projectProperties = new ProjectProperties(
-      getProjectName(),
-      isTopLevelProject(),
-      compileClasspathFilenames,
-      testCompileClasspathFilenames,
-      mainLibrariesFilenames,
-      testLibrariesFilenames,
-      androidSourcesFilenames,
-      androidTestsFilenames
-    );
+    ProjectProperties projectProperties = new ProjectProperties.Builder()
+      .projectName(getProjectName())
+      .isRootProject(isTopLevelProject())
+      .compileClasspath(compileClasspathFilenames)
+      .testCompileClasspath(testCompileClasspathFilenames)
+      .mainLibraries(mainLibrariesFilenames)
+      .testLibraries(testLibrariesFilenames)
+      .androidSources(androidSourcesFilenames)
+      .androidTests(androidTestsFilenames)
+      .build();
 
     outputDirectory.mkdirs();
     ResolutionSerializer.write(

--- a/src/main/java/org/sonarqube/gradle/SonarResolverTask.java
+++ b/src/main/java/org/sonarqube/gradle/SonarResolverTask.java
@@ -53,7 +53,7 @@ public abstract class SonarResolverTask extends DefaultTask {
   private Provider<Boolean> skipProject;
 
   @Inject
-  protected SonarResolverTask() {
+  public SonarResolverTask() {
     super();
     // Some inputs are annotated with internal, thus grade cannot correctly compute if the task is up to date or not.
     this.getOutputs().upToDateWhen(task -> false);

--- a/src/main/java/org/sonarqube/gradle/SonarResolverTask.java
+++ b/src/main/java/org/sonarqube/gradle/SonarResolverTask.java
@@ -189,9 +189,7 @@ public abstract class SonarResolverTask extends DefaultTask {
     Provider<FileCollection> androidTestsProvider = getAndroidTests();
     List<String> androidTestsFilenames = androidTestsProvider == null ? Collections.emptyList() : getAbsolutePaths(androidTestsProvider);
 
-    ProjectProperties projectProperties = new ProjectProperties.Builder()
-      .projectName(getProjectName())
-      .isRootProject(isTopLevelProject())
+    ProjectProperties projectProperties = new ProjectProperties.Builder(getProjectName(), isTopLevelProject())
       .compileClasspath(compileClasspathFilenames)
       .testCompileClasspath(testCompileClasspathFilenames)
       .mainLibraries(mainLibrariesFilenames)

--- a/src/test/java/org/sonarqube/gradle/ResolutionSerializerTest.java
+++ b/src/test/java/org/sonarqube/gradle/ResolutionSerializerTest.java
@@ -53,9 +53,7 @@ class ResolutionSerializerTest {
     List<String> androidTests
   ) throws IOException {
     File file = tempDir.resolve("test.json").toFile();
-    ProjectProperties properties = new ProjectProperties.Builder()
-      .projectName(TEST_PROJECT_NAME)
-      .isRootProject(true)
+    ProjectProperties properties = new ProjectProperties.Builder(TEST_PROJECT_NAME, true)
       .compileClasspath(compileClasspath)
       .testCompileClasspath(testCompileClasspath)
       .mainLibraries(mainLibraries)
@@ -92,16 +90,7 @@ class ResolutionSerializerTest {
   @Test
   void testWriteReadWithoutProperties() throws IOException {
     File file = tempDir.resolve("test.json").toFile();
-    List<String> emptyList = Collections.emptyList();
-    ProjectProperties properties = new ProjectProperties.Builder()
-      .projectName(TEST_PROJECT_NAME)
-      .isRootProject(false)
-      .compileClasspath(emptyList)
-      .testCompileClasspath(emptyList)
-      .mainLibraries(emptyList)
-      .testLibraries(emptyList)
-      .androidTests(emptyList)
-      .androidSources(emptyList)
+    ProjectProperties properties = new ProjectProperties.Builder(TEST_PROJECT_NAME, false)
       .build();
 
     ResolutionSerializer.write(file, properties);

--- a/src/test/java/org/sonarqube/gradle/ResolutionSerializerTest.java
+++ b/src/test/java/org/sonarqube/gradle/ResolutionSerializerTest.java
@@ -90,9 +90,7 @@ class ResolutionSerializerTest {
   @Test
   void testWriteReadWithoutProperties() throws IOException {
     File file = tempDir.resolve("test.json").toFile();
-    ProjectProperties properties = new ProjectProperties.Builder(TEST_PROJECT_NAME, false)
-      .build();
-
+    ProjectProperties properties = new ProjectProperties.Builder(TEST_PROJECT_NAME, false).build();
     ResolutionSerializer.write(file, properties);
     Optional<ProjectProperties> readProperties = ResolutionSerializer.read(file);
 

--- a/src/test/java/org/sonarqube/gradle/ResolutionSerializerTest.java
+++ b/src/test/java/org/sonarqube/gradle/ResolutionSerializerTest.java
@@ -53,16 +53,16 @@ class ResolutionSerializerTest {
     List<String> androidTests
   ) throws IOException {
     File file = tempDir.resolve("test.json").toFile();
-    ProjectProperties properties = new ProjectProperties(
-      TEST_PROJECT_NAME,
-      true,
-      compileClasspath,
-      testCompileClasspath,
-      mainLibraries,
-      testLibraries,
-      androidSources,
-      androidTests
-    );
+    ProjectProperties properties = new ProjectProperties.Builder()
+      .projectName(TEST_PROJECT_NAME)
+      .isRootProject(true)
+      .compileClasspath(compileClasspath)
+      .testCompileClasspath(testCompileClasspath)
+      .mainLibraries(mainLibraries)
+      .testLibraries(testLibraries)
+      .androidSources(androidSources)
+      .androidTests(androidTests)
+      .build();
 
     ResolutionSerializer.write(file, properties);
     Optional<ProjectProperties> readProperties = ResolutionSerializer.read(file);
@@ -93,7 +93,16 @@ class ResolutionSerializerTest {
   void testWriteReadWithoutProperties() throws IOException {
     File file = tempDir.resolve("test.json").toFile();
     List<String> emptyList = Collections.emptyList();
-    ProjectProperties properties = new ProjectProperties(TEST_PROJECT_NAME, false, emptyList, emptyList, emptyList, emptyList, emptyList, emptyList);
+    ProjectProperties properties = new ProjectProperties.Builder()
+      .projectName(TEST_PROJECT_NAME)
+      .isRootProject(false)
+      .compileClasspath(emptyList)
+      .testCompileClasspath(emptyList)
+      .mainLibraries(emptyList)
+      .testLibraries(emptyList)
+      .androidTests(emptyList)
+      .androidSources(emptyList)
+      .build();
 
     ResolutionSerializer.write(file, properties);
     Optional<ProjectProperties> readProperties = ResolutionSerializer.read(file);

--- a/src/test/java/org/sonarqube/gradle/SonarTaskTest.java
+++ b/src/test/java/org/sonarqube/gradle/SonarTaskTest.java
@@ -34,8 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class SonarTaskTest {
 
-  private final ProjectProperties projectProperties = new ProjectProperties.Builder("", true)
-    .build();
+  private final ProjectProperties projectProperties = new ProjectProperties.Builder("", true).build();
 
   @Test
   void resolveSonarJavaLibraries_skips_resolution_when_no_configuration_provided() {
@@ -65,8 +64,7 @@ class SonarTaskTest {
     File emptyJar = new File(tempDir, "empty.jar");
     emptyJar.createNewFile();
     List<File> fileCollection = List.of(emptyJar);
-    ProjectProperties subprojectProperties = new ProjectProperties.Builder(":subproject", false)
-      .build();
+    ProjectProperties subprojectProperties = new ProjectProperties.Builder(":subproject", false).build();
     SonarTask.resolveSonarJavaLibraries(subprojectProperties, fileCollection, properties);
     assertThat(properties)
       .hasSize(2)
@@ -118,8 +116,7 @@ class SonarTaskTest {
     File emptyJar = new File(tempDir, "empty.jar");
     emptyJar.createNewFile();
     List<File> fileCollection = List.of(emptyJar);
-    ProjectProperties subprojectProperties = new ProjectProperties.Builder(":subproject", false)
-      .build();
+    ProjectProperties subprojectProperties = new ProjectProperties.Builder(":subproject", false).build();
     SonarTask.resolveSonarJavaTestLibraries(subprojectProperties, fileCollection, properties);
     assertThat(properties)
       .hasSize(1)
@@ -214,8 +211,7 @@ class SonarTaskTest {
     File sourceDirectory = new File(tempDir, "src/main/java");
     sourceDirectory.mkdirs();
     List<File> fileCollection = List.of(sourceDirectory);
-    ProjectProperties subprojectProperties = new ProjectProperties.Builder(":subproject", false)
-      .build();
+    ProjectProperties subprojectProperties = new ProjectProperties.Builder(":subproject", false).build();
     SonarTask.resolveAndroidSources(subprojectProperties, fileCollection, properties, false);
     assertThat(properties)
       .hasSize(1)

--- a/src/test/java/org/sonarqube/gradle/SonarTaskTest.java
+++ b/src/test/java/org/sonarqube/gradle/SonarTaskTest.java
@@ -302,7 +302,7 @@ class SonarTaskTest {
       .projectName("")
       .isRootProject(true)
       .compileClasspath(List.of(lib1.toAbsolutePath().toString(), lib2.toAbsolutePath().toString()))
-      .testCompileClasspath( List.of(testLib1.toAbsolutePath().toString()))
+      .testCompileClasspath(List.of(testLib1.toAbsolutePath().toString()))
       .mainLibraries(List.of())
       .testLibraries(List.of())
       .androidSources(List.of())

--- a/src/test/java/org/sonarqube/gradle/SonarTaskTest.java
+++ b/src/test/java/org/sonarqube/gradle/SonarTaskTest.java
@@ -34,7 +34,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class SonarTaskTest {
 
-  private final ProjectProperties projectProperties = new ProjectProperties("", true, List.of(), List.of(), List.of(), List.of(), List.of(), List.of());
+  private final ProjectProperties projectProperties = new ProjectProperties.Builder()
+    .projectName("")
+    .isRootProject(true)
+    .compileClasspath(List.of())
+    .testCompileClasspath(List.of())
+    .mainLibraries(List.of())
+    .testLibraries(List.of())
+    .androidSources(List.of())
+    .androidTests(List.of())
+    .build();
 
   @Test
   void resolveSonarJavaLibraries_skips_resolution_when_no_configuration_provided() {
@@ -64,7 +73,16 @@ class SonarTaskTest {
     File emptyJar = new File(tempDir, "empty.jar");
     emptyJar.createNewFile();
     List<File> fileCollection = List.of(emptyJar);
-    ProjectProperties subprojectProperties = new ProjectProperties(":subproject", false, List.of(), List.of(), List.of(), List.of(), List.of(), List.of());
+    ProjectProperties subprojectProperties = new ProjectProperties.Builder()
+      .projectName(":subproject")
+      .isRootProject(false)
+      .compileClasspath(List.of())
+      .testCompileClasspath(List.of())
+      .mainLibraries(List.of())
+      .testLibraries(List.of())
+      .androidSources(List.of())
+      .androidTests(List.of())
+      .build();
     SonarTask.resolveSonarJavaLibraries(subprojectProperties, fileCollection, properties);
     assertThat(properties)
       .hasSize(2)
@@ -116,7 +134,16 @@ class SonarTaskTest {
     File emptyJar = new File(tempDir, "empty.jar");
     emptyJar.createNewFile();
     List<File> fileCollection = List.of(emptyJar);
-    ProjectProperties subprojectProperties = new ProjectProperties(":subproject", false, List.of(), List.of(), List.of(), List.of(), List.of(), List.of());
+    ProjectProperties subprojectProperties = new ProjectProperties.Builder()
+      .projectName(":subproject")
+      .isRootProject(false)
+      .compileClasspath(List.of())
+      .testCompileClasspath(List.of())
+      .mainLibraries(List.of())
+      .testLibraries(List.of())
+      .androidSources(List.of())
+      .androidTests(List.of())
+      .build();
     SonarTask.resolveSonarJavaTestLibraries(subprojectProperties, fileCollection, properties);
     assertThat(properties)
       .hasSize(1)
@@ -211,7 +238,16 @@ class SonarTaskTest {
     File sourceDirectory = new File(tempDir, "src/main/java");
     sourceDirectory.mkdirs();
     List<File> fileCollection = List.of(sourceDirectory);
-    ProjectProperties subprojectProperties = new ProjectProperties(":subproject", false, List.of(), List.of(), List.of(), List.of(), List.of(), List.of());
+    ProjectProperties subprojectProperties = new ProjectProperties.Builder()
+      .projectName(":subproject")
+      .isRootProject(false)
+      .compileClasspath(List.of())
+      .testCompileClasspath(List.of())
+      .mainLibraries(List.of())
+      .testLibraries(List.of())
+      .androidSources(List.of())
+      .androidTests(List.of())
+      .build();
     SonarTask.resolveAndroidSources(subprojectProperties, fileCollection, properties, false);
     assertThat(properties)
       .hasSize(1)
@@ -262,13 +298,16 @@ class SonarTaskTest {
     Path lib2 = Files.createFile(tempDir.toPath().resolve("lib2.jar"));
     Path testLib1 = Files.createFile(tempDir.toPath().resolve("testlib1.jar"));
 
-    ProjectProperties props = new ProjectProperties("", true,
-      List.of(lib1.toAbsolutePath().toString(), lib2.toAbsolutePath().toString()),
-      List.of(testLib1.toAbsolutePath().toString()),
-      List.of(),
-      List.of(),
-      List.of(),
-      List.of());
+    ProjectProperties props = new ProjectProperties.Builder()
+      .projectName("")
+      .isRootProject(true)
+      .compileClasspath(List.of(lib1.toAbsolutePath().toString(), lib2.toAbsolutePath().toString()))
+      .testCompileClasspath( List.of(testLib1.toAbsolutePath().toString()))
+      .mainLibraries(List.of())
+      .testLibraries(List.of())
+      .androidSources(List.of())
+      .androidTests(List.of())
+      .build();
     ResolutionSerializer.write(resolverFile, props);
     SonarTask.processResolverFile(resolverFile, result);
     assertThat(result)

--- a/src/test/java/org/sonarqube/gradle/SonarTaskTest.java
+++ b/src/test/java/org/sonarqube/gradle/SonarTaskTest.java
@@ -34,15 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class SonarTaskTest {
 
-  private final ProjectProperties projectProperties = new ProjectProperties.Builder()
-    .projectName("")
-    .isRootProject(true)
-    .compileClasspath(List.of())
-    .testCompileClasspath(List.of())
-    .mainLibraries(List.of())
-    .testLibraries(List.of())
-    .androidSources(List.of())
-    .androidTests(List.of())
+  private final ProjectProperties projectProperties = new ProjectProperties.Builder("", true)
     .build();
 
   @Test
@@ -73,15 +65,7 @@ class SonarTaskTest {
     File emptyJar = new File(tempDir, "empty.jar");
     emptyJar.createNewFile();
     List<File> fileCollection = List.of(emptyJar);
-    ProjectProperties subprojectProperties = new ProjectProperties.Builder()
-      .projectName(":subproject")
-      .isRootProject(false)
-      .compileClasspath(List.of())
-      .testCompileClasspath(List.of())
-      .mainLibraries(List.of())
-      .testLibraries(List.of())
-      .androidSources(List.of())
-      .androidTests(List.of())
+    ProjectProperties subprojectProperties = new ProjectProperties.Builder(":subproject", false)
       .build();
     SonarTask.resolveSonarJavaLibraries(subprojectProperties, fileCollection, properties);
     assertThat(properties)
@@ -134,15 +118,7 @@ class SonarTaskTest {
     File emptyJar = new File(tempDir, "empty.jar");
     emptyJar.createNewFile();
     List<File> fileCollection = List.of(emptyJar);
-    ProjectProperties subprojectProperties = new ProjectProperties.Builder()
-      .projectName(":subproject")
-      .isRootProject(false)
-      .compileClasspath(List.of())
-      .testCompileClasspath(List.of())
-      .mainLibraries(List.of())
-      .testLibraries(List.of())
-      .androidSources(List.of())
-      .androidTests(List.of())
+    ProjectProperties subprojectProperties = new ProjectProperties.Builder(":subproject", false)
       .build();
     SonarTask.resolveSonarJavaTestLibraries(subprojectProperties, fileCollection, properties);
     assertThat(properties)
@@ -238,15 +214,7 @@ class SonarTaskTest {
     File sourceDirectory = new File(tempDir, "src/main/java");
     sourceDirectory.mkdirs();
     List<File> fileCollection = List.of(sourceDirectory);
-    ProjectProperties subprojectProperties = new ProjectProperties.Builder()
-      .projectName(":subproject")
-      .isRootProject(false)
-      .compileClasspath(List.of())
-      .testCompileClasspath(List.of())
-      .mainLibraries(List.of())
-      .testLibraries(List.of())
-      .androidSources(List.of())
-      .androidTests(List.of())
+    ProjectProperties subprojectProperties = new ProjectProperties.Builder(":subproject", false)
       .build();
     SonarTask.resolveAndroidSources(subprojectProperties, fileCollection, properties, false);
     assertThat(properties)
@@ -298,15 +266,9 @@ class SonarTaskTest {
     Path lib2 = Files.createFile(tempDir.toPath().resolve("lib2.jar"));
     Path testLib1 = Files.createFile(tempDir.toPath().resolve("testlib1.jar"));
 
-    ProjectProperties props = new ProjectProperties.Builder()
-      .projectName("")
-      .isRootProject(true)
+    ProjectProperties props = new ProjectProperties.Builder("", true)
       .compileClasspath(List.of(lib1.toAbsolutePath().toString(), lib2.toAbsolutePath().toString()))
       .testCompileClasspath(List.of(testLib1.toAbsolutePath().toString()))
-      .mainLibraries(List.of())
-      .testLibraries(List.of())
-      .androidSources(List.of())
-      .androidTests(List.of())
       .build();
     ResolutionSerializer.write(resolverFile, props);
     SonarTask.processResolverFile(resolverFile, result);


### PR DESCRIPTION
Replace the simple constructor of the ProjectProperties class with a Builder pattern.