### PR TITLE
SCANGRADLE-421 Code Quality reorganization from jvm to CI Experience Squad

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/CODEOWNERS @SonarSource/quality-jvm-squad
+* @SonarSource/code-quality-ci-experience-squad

--- a/.github/workflows/ToggleLockBranch.yml
+++ b/.github/workflows/ToggleLockBranch.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).lock_token }}
           slack-token: ${{ fromJSON(steps.secrets.outputs.vault).slack_api_token }}
-          slack-channel: squad-jvm-notifs
+          slack-channel: ops-ci-experience

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -21,4 +21,4 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         uses: SonarSource/gh-action_slack-notify@v1
         with:
-          slackChannel: squad-jvm-notifs
+          slackChannel: ops-ci-experience


### PR DESCRIPTION
----
## Summary by Gitar

- **Code ownership:**
  - Update `CODEOWNERS` to reassign repository oversight from `@SonarSource/quality-jvm-squad` to `@SonarSource/code-quality-ci-experience-squad`.
- **CI/CD configuration:**
  - Update `ToggleLockBranch.yml` and `slack_notify.yml` to redirect Slack notifications to the `ops-ci-experience` channel.

<sub>This will update automatically on new commits.</sub>