### PR TITLE
SCANGRADLE-423 Add Gradle 9.6.1 to ITs matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,10 @@ jobs:
       matrix:
         item:
         # Make sure to move `&latest-gradle-version` when adding a new test case with a new version.
-          - gradle_version: &latest-gradle-version "9.5.1"
+          - gradle_version: &latest-gradle-version "9.6.1"
+            android_gradle_version: "9.2.0"
+            java_version: "21"
+          - gradle_version: "9.5.1"
             android_gradle_version: "9.2.0"
             java_version: "21"
           - gradle_version: "9.4.1"


### PR DESCRIPTION
Part of SCANGRADLE-423

## Summary
- Add Gradle 9.6.1 as the latest QA IT matrix entry and keep 9.5.1 coverage.

## Verification
- git diff --check
- Verified the Gradle 9.6.1 distribution URL resolves successfully