### PR TITLE
SCANGRADLE-431 Prevent potential NPE when looking up source sets

### DIFF
--- a/src/main/java/org/sonarqube/gradle/SonarPropertyComputer.java
+++ b/src/main/java/org/sonarqube/gradle/SonarPropertyComputer.java
@@ -469,22 +469,23 @@ public class SonarPropertyComputer {
 
   private static void configureSourceDirsAndJavaClasspath(Project project, Map<String, Object> properties, boolean addForGroovy) {
     SourceSetContainer sourceSets = getSourceSets(project);
+    if (sourceSets != null) {
+      SourceSet main = sourceSets.getAt("main");
+      Collection<File> sourceDirectories = getJavaSourceFiles(main);
+      if (sourceDirectories != null) {
+        SonarUtils.appendSourcesProp(properties, sourceDirectories, false);
+      }
 
-    SourceSet main = sourceSets.getAt("main");
-    Collection<File> sourceDirectories = getJavaSourceFiles(main);
-    if (sourceDirectories != null) {
-      SonarUtils.appendSourcesProp(properties, sourceDirectories, false);
-    }
+      SourceSet test = sourceSets.getAt("test");
+      Collection<File> testDirectories = getJavaSourceFiles(test);
+      if (testDirectories != null) {
+        SonarUtils.appendSourcesProp(properties, testDirectories, true);
+      }
 
-    SourceSet test = sourceSets.getAt("test");
-    Collection<File> testDirectories = getJavaSourceFiles(test);
-    if (testDirectories != null) {
-      SonarUtils.appendSourcesProp(properties, testDirectories, true);
-    }
-
-    if (sourceDirectories != null || testDirectories != null) {
-      configureSourceEncoding(project, properties);
-      extractTestProperties(project, properties);
+      if (sourceDirectories != null || testDirectories != null) {
+        configureSourceEncoding(project, properties);
+        extractTestProperties(project, properties);
+      }
     }
 
     configureJavaClasspath(project, properties, addForGroovy);


### PR DESCRIPTION
----
## Summary by Gitar

- **Null Safety:**
  - Added null check for `SourceSetContainer` in `SonarPropertyComputer` to prevent NPEs during source set lookups.

<sub>This will update automatically on new commits.</sub>