### PR TITLE
SCANGRADLE-441 Order classpath producers without adding dependencies

### DIFF
--- a/src/main/java/org/sonarqube/gradle/SonarResolverTask.java
+++ b/src/main/java/org/sonarqube/gradle/SonarResolverTask.java
@@ -21,9 +21,13 @@ package org.sonarqube.gradle;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Queue;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -31,6 +35,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.Task;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Property;
@@ -78,13 +83,13 @@ public abstract class SonarResolverTask extends DefaultTask {
   public void setCompileClasspath(Provider<FileCollection> compileClasspath) {
     this.compileClasspath = compileClasspath;
     this.getCompileClasspath().setFrom(compileClasspath.map(SonarResolverTask::getClasspathEntries));
-    this.getCompileClasspath().builtBy(getBuildDependencies(compileClasspath));
+    this.mustRunAfter(getClasspathProducerOrdering(compileClasspath));
   }
 
   public void setTestCompileClasspath(Provider<FileCollection> testCompileClasspath) {
     this.testCompileClasspath = testCompileClasspath;
     this.getTestCompileClasspath().setFrom(testCompileClasspath.map(SonarResolverTask::getClasspathEntries));
-    this.getTestCompileClasspath().builtBy(getBuildDependencies(testCompileClasspath));
+    this.mustRunAfter(getClasspathProducerOrdering(testCompileClasspath));
   }
 
   public void setLegacyMainLibraries(Provider<FileCollection> legacyMainLibraries) {
@@ -185,17 +190,41 @@ public abstract class SonarResolverTask extends DefaultTask {
     }
   }
 
-  private static TaskDependency getBuildDependencies(Provider<FileCollection> filesProvider) {
+  /**
+   * Lazily finds all tasks that may produce the classpath.
+   * <p>
+   * A FileCollection can expose an aggregate producer such as {@code classes}. If only one of its dependencies, such
+   * as {@code processResources}, is selected, the aggregate task is absent from the task graph. Ordering sonarResolver
+   * only after the aggregate task would therefore not satisfy Gradle's implicit-dependency validation.
+   * <p>
+   * Including transitive task dependencies ensures every selected concrete producer is ordered before sonarResolver,
+   * without making it a task dependency.
+   */
+  private static TaskDependency getClasspathProducerOrdering(Provider<FileCollection> filesProvider) {
     return task -> {
       try {
-        // Preserve producer tasks independently from the guarded classpath value resolution above.
         FileCollection files = filesProvider.getOrNull();
-        return files == null ? Collections.emptySet() : files.getBuildDependencies().getDependencies(task);
+        if (files == null) {
+          return Collections.emptySet();
+        }
+        return collectTransitiveTaskDependencies(task, files.getBuildDependencies().getDependencies(task));
       } catch (RuntimeException e) {
         LOGGER.log(Level.WARNING, FILE_COLLECTION_RESOLUTION_FAILURE_MESSAGE, e);
         return Collections.emptySet();
       }
     };
+  }
+
+  private static Set<Task> collectTransitiveTaskDependencies(Task consumer, Set<? extends Task> producerTasks) {
+    Set<Task> orderedProducers = new HashSet<>();
+    Queue<Task> queue = new ArrayDeque<>(producerTasks);
+    while (!queue.isEmpty()) {
+      Task producer = queue.remove();
+      if (producer != consumer && orderedProducers.add(producer)) {
+        queue.addAll(producer.getTaskDependencies().getDependencies(producer));
+      }
+    }
+    return orderedProducers;
   }
 
   @TaskAction

--- a/src/main/java/org/sonarqube/gradle/SonarResolverTask.java
+++ b/src/main/java/org/sonarqube/gradle/SonarResolverTask.java
@@ -42,6 +42,7 @@ import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.TaskDependency;
 
 
 public abstract class SonarResolverTask extends DefaultTask {
@@ -76,12 +77,14 @@ public abstract class SonarResolverTask extends DefaultTask {
 
   public void setCompileClasspath(Provider<FileCollection> compileClasspath) {
     this.compileClasspath = compileClasspath;
-    this.getCompileClasspath().setFrom(compileClasspath.map(SonarResolverTask::filterExistingClasspathEntries));
+    this.getCompileClasspath().setFrom(compileClasspath.map(SonarResolverTask::getClasspathEntries));
+    this.getCompileClasspath().builtBy(getBuildDependencies(compileClasspath));
   }
 
   public void setTestCompileClasspath(Provider<FileCollection> testCompileClasspath) {
     this.testCompileClasspath = testCompileClasspath;
-    this.getTestCompileClasspath().setFrom(testCompileClasspath.map(SonarResolverTask::filterExistingClasspathEntries));
+    this.getTestCompileClasspath().setFrom(testCompileClasspath.map(SonarResolverTask::getClasspathEntries));
+    this.getTestCompileClasspath().builtBy(getBuildDependencies(testCompileClasspath));
   }
 
   public void setLegacyMainLibraries(Provider<FileCollection> legacyMainLibraries) {
@@ -171,8 +174,28 @@ public abstract class SonarResolverTask extends DefaultTask {
     return filenames;
   }
 
-  private static FileCollection filterExistingClasspathEntries(FileCollection fileCollection) {
-    return fileCollection.filter(File::exists);
+  private static List<File> getClasspathEntries(FileCollection fileCollection) {
+    try {
+      // Keep missing producer outputs in the tracked value so configuration-cache state does not depend on
+      // whether those outputs exist while Gradle constructs the task graph. Serialization filters them later.
+      return new ArrayList<>(fileCollection.getFiles());
+    } catch (RuntimeException e) {
+      LOGGER.log(Level.WARNING, FILE_COLLECTION_RESOLUTION_FAILURE_MESSAGE, e);
+      return Collections.emptyList();
+    }
+  }
+
+  private static TaskDependency getBuildDependencies(Provider<FileCollection> filesProvider) {
+    return task -> {
+      try {
+        // Preserve producer tasks independently from the guarded classpath value resolution above.
+        FileCollection files = filesProvider.getOrNull();
+        return files == null ? Collections.emptySet() : files.getBuildDependencies().getDependencies(task);
+      } catch (RuntimeException e) {
+        LOGGER.log(Level.WARNING, FILE_COLLECTION_RESOLUTION_FAILURE_MESSAGE, e);
+        return Collections.emptySet();
+      }
+    };
   }
 
   @TaskAction

--- a/src/main/java/org/sonarqube/gradle/SonarResolverTask.java
+++ b/src/main/java/org/sonarqube/gradle/SonarResolverTask.java
@@ -76,12 +76,12 @@ public abstract class SonarResolverTask extends DefaultTask {
 
   public void setCompileClasspath(Provider<FileCollection> compileClasspath) {
     this.compileClasspath = compileClasspath;
-    this.getCompileClasspath().setFrom(compileClasspath.map(SonarResolverTask::getExistingClasspathEntries));
+    this.getCompileClasspath().setFrom(compileClasspath.map(SonarResolverTask::filterExistingClasspathEntries));
   }
 
   public void setTestCompileClasspath(Provider<FileCollection> testCompileClasspath) {
     this.testCompileClasspath = testCompileClasspath;
-    this.getTestCompileClasspath().setFrom(testCompileClasspath.map(SonarResolverTask::getExistingClasspathEntries));
+    this.getTestCompileClasspath().setFrom(testCompileClasspath.map(SonarResolverTask::filterExistingClasspathEntries));
   }
 
   public void setLegacyMainLibraries(Provider<FileCollection> legacyMainLibraries) {
@@ -171,13 +171,8 @@ public abstract class SonarResolverTask extends DefaultTask {
     return filenames;
   }
 
-  private static List<File> getExistingClasspathEntries(FileCollection fileCollection) {
-    try {
-      return SonarUtils.exists(fileCollection);
-    } catch (RuntimeException e) {
-      LOGGER.log(Level.WARNING, FILE_COLLECTION_RESOLUTION_FAILURE_MESSAGE, e);
-      return Collections.emptyList();
-    }
+  private static FileCollection filterExistingClasspathEntries(FileCollection fileCollection) {
+    return fileCollection.filter(File::exists);
   }
 
   @TaskAction

--- a/src/main/java/org/sonarqube/gradle/SonarResolverTask.java
+++ b/src/main/java/org/sonarqube/gradle/SonarResolverTask.java
@@ -216,15 +216,15 @@ public abstract class SonarResolverTask extends DefaultTask {
   }
 
   private static Set<Task> collectTransitiveTaskDependencies(Task consumer, Set<? extends Task> producerTasks) {
-    Set<Task> orderedProducers = new HashSet<>();
+    Set<Task> producersToOrderAfter = new HashSet<>();
     Queue<Task> queue = new ArrayDeque<>(producerTasks);
     while (!queue.isEmpty()) {
       Task producer = queue.remove();
-      if (producer != consumer && orderedProducers.add(producer)) {
+      if (producer != consumer && producersToOrderAfter.add(producer)) {
         queue.addAll(producer.getTaskDependencies().getDependencies(producer));
       }
     }
-    return orderedProducers;
+    return producersToOrderAfter;
   }
 
   @TaskAction

--- a/src/test/groovy/org/sonarqube/gradle/FunctionalTests.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/FunctionalTests.groovy
@@ -800,7 +800,7 @@ class FunctionalTests extends Specification {
     then:
     def sonarResolver = multiModuleProjectDir.resolve("module-1/build/sonar-resolver")
     assert result.task(":sonar").getOutcome() == SUCCESS
-    assert Files.notExists(sonarResolver)
+    assert Files.notExists(sonarResolver.resolve("properties"))
 
   }
 

--- a/src/test/groovy/org/sonarqube/gradle/FunctionalTests.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/FunctionalTests.groovy
@@ -1012,6 +1012,48 @@ class FunctionalTests extends Specification {
     resolverProperties.testCompileClasspath.contains(resourcesOutput)
   }
 
+  def "sonarResolver skips compile classpaths that fail to resolve"() {
+    given:
+    settingsFile << "rootProject.name = 'root'"
+    Files.createDirectories(projectDir.resolve("empty-repository"))
+    writeFile(projectDir.resolve("existing-library.txt"), "existing library")
+    buildFile << """
+        plugins {
+            id 'org.sonarqube'
+            id 'java-library'
+        }
+
+        repositories {
+            maven { url = uri('empty-repository') }
+        }
+
+        dependencies {
+            implementation 'invalid.example:missing-artifact:1.0'
+        }
+
+        tasks.named('sonarResolver') {
+            mainLibraries.from(file('existing-library.txt'))
+        }
+        """
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(projectDir.toFile())
+      .withGradleVersion("9.5.1")
+      .forwardOutput()
+      .withPluginClasspath()
+      .withArguments(':sonarResolver')
+      .build()
+
+    then:
+    result.task(":sonarResolver").getOutcome() == SUCCESS
+    result.output.contains("Failed to resolve file collection input; skipping it.")
+    def resolverPropertiesFile = projectDir.resolve("build/sonar-resolver/properties").toFile()
+    def resolverProperties = new JsonSlurper().parse(resolverPropertiesFile)
+    resolverProperties.compileClasspath.isEmpty()
+    resolverProperties.testCompileClasspath.isEmpty()
+  }
+
   def "sonarResolver tracks a Kotlin Multiplatform JVM artifact through jvmJar"() {
     given:
     settingsFile << """

--- a/src/test/groovy/org/sonarqube/gradle/FunctionalTests.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/FunctionalTests.groovy
@@ -1106,11 +1106,13 @@ class FunctionalTests extends Specification {
     result.tasks*.path.indexOf(":subdependency:jvmJar") < result.tasks*.path.indexOf(":consumer:sonarResolver")
     def resolverPropertiesFile = projectDir.resolve("consumer/build/sonar-resolver/properties").toFile()
     def resolverProperties = new JsonSlurper().parse(resolverPropertiesFile)
-    resolverProperties.compileClasspath.any {
+    def jvmJarPath = resolverProperties.compileClasspath.find {
       it.startsWith(projectDir.resolve("subdependency/build/libs").toAbsolutePath().toString()) && it.endsWith(".jar")
     }
+    jvmJarPath != null
 
     when:
+    Files.delete(resolverPropertiesFile.toPath())
     def resolverOnlyResult = GradleRunner.create()
       .withProjectDir(projectDir.toFile())
       .withGradleVersion("9.5.1")
@@ -1123,9 +1125,7 @@ class FunctionalTests extends Specification {
     resolverOnlyResult.task(":subdependency:jvmJar") == null
     resolverOnlyResult.task(":consumer:sonarResolver").getOutcome() == SUCCESS
     def resolverOnlyProperties = new JsonSlurper().parse(resolverPropertiesFile)
-    resolverOnlyProperties.compileClasspath.any {
-      it.startsWith(projectDir.resolve("subdependency/build/libs").toAbsolutePath().toString()) && it.endsWith(".jar")
-    }
+    resolverOnlyProperties.compileClasspath.contains(jvmJarPath)
   }
 
   private Path projectDir(String project) {

--- a/src/test/groovy/org/sonarqube/gradle/FunctionalTests.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/FunctionalTests.groovy
@@ -800,7 +800,7 @@ class FunctionalTests extends Specification {
     then:
     def sonarResolver = multiModuleProjectDir.resolve("module-1/build/sonar-resolver")
     assert result.task(":sonar").getOutcome() == SUCCESS
-    assert Files.list(sonarResolver).count() == 0
+    assert Files.notExists(sonarResolver)
 
   }
 
@@ -1005,6 +1005,7 @@ class FunctionalTests extends Specification {
     then:
     result.task(":processResources").getOutcome() == SUCCESS
     result.task(":sonarResolver").getOutcome() == SUCCESS
+    result.tasks*.path.indexOf(":processResources") < result.tasks*.path.indexOf(":sonarResolver")
     def resolverPropertiesFile = projectDir.resolve("build/sonar-resolver/properties").toFile()
     def resolverProperties = new JsonSlurper().parse(resolverPropertiesFile)
     def resourcesOutput = projectDir.resolve("build/resources/main").toAbsolutePath().toString()
@@ -1094,15 +1095,33 @@ class FunctionalTests extends Specification {
       .withGradleVersion("9.5.1")
       .forwardOutput()
       .withPluginClasspath()
-      .withArguments(':consumer:sonarResolver')
+      .withArguments(':consumer:sonarResolver', ':subdependency:jvmJar')
       .build()
 
     then:
     result.task(":subdependency:jvmJar").getOutcome() == SUCCESS
     result.task(":consumer:sonarResolver").getOutcome() == SUCCESS
+    result.tasks*.path.indexOf(":subdependency:jvmJar") < result.tasks*.path.indexOf(":consumer:sonarResolver")
     def resolverPropertiesFile = projectDir.resolve("consumer/build/sonar-resolver/properties").toFile()
     def resolverProperties = new JsonSlurper().parse(resolverPropertiesFile)
     resolverProperties.compileClasspath.any {
+      it.startsWith(projectDir.resolve("subdependency/build/libs").toAbsolutePath().toString()) && it.endsWith(".jar")
+    }
+
+    when:
+    def resolverOnlyResult = GradleRunner.create()
+      .withProjectDir(projectDir.toFile())
+      .withGradleVersion("9.5.1")
+      .forwardOutput()
+      .withPluginClasspath()
+      .withArguments(':consumer:sonarResolver', '--rerun-tasks')
+      .build()
+
+    then:
+    resolverOnlyResult.task(":subdependency:jvmJar") == null
+    resolverOnlyResult.task(":consumer:sonarResolver").getOutcome() == SUCCESS
+    def resolverOnlyProperties = new JsonSlurper().parse(resolverPropertiesFile)
+    resolverOnlyProperties.compileClasspath.any {
       it.startsWith(projectDir.resolve("subdependency/build/libs").toAbsolutePath().toString()) && it.endsWith(".jar")
     }
   }

--- a/src/test/groovy/org/sonarqube/gradle/FunctionalTests.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/FunctionalTests.groovy
@@ -1008,9 +1008,10 @@ class FunctionalTests extends Specification {
     result.tasks*.path.indexOf(":processResources") < result.tasks*.path.indexOf(":sonarResolver")
     def resolverPropertiesFile = projectDir.resolve("build/sonar-resolver/properties").toFile()
     def resolverProperties = new JsonSlurper().parse(resolverPropertiesFile)
-    def resourcesOutput = projectDir.resolve("build/resources/main").toAbsolutePath().toString()
-    new File(resourcesOutput).exists()
-    resolverProperties.testCompileClasspath.contains(resourcesOutput)
+    def resourcesOutput = projectDir.resolve("build/resources/main").toRealPath()
+    resolverProperties.testCompileClasspath
+      .collect { existingRealPathOrNormalizedPath(it) }
+      .contains(resourcesOutput)
   }
 
   def "sonarResolver skips compile classpaths that fail to resolve"() {
@@ -1054,7 +1055,7 @@ class FunctionalTests extends Specification {
     def resolverProperties = new JsonSlurper().parse(resolverPropertiesFile)
     resolverProperties.compileClasspath.isEmpty()
     resolverProperties.testCompileClasspath.isEmpty()
-    resolverProperties.mainLibraries == [existingLibrary.toAbsolutePath().toString()]
+    resolverProperties.mainLibraries.collect { existingRealPathOrNormalizedPath(it) } == [existingLibrary.toRealPath()]
   }
 
   def "sonarResolver tracks a Kotlin Multiplatform JVM artifact through jvmJar"() {
@@ -1106,8 +1107,10 @@ class FunctionalTests extends Specification {
     result.tasks*.path.indexOf(":subdependency:jvmJar") < result.tasks*.path.indexOf(":consumer:sonarResolver")
     def resolverPropertiesFile = projectDir.resolve("consumer/build/sonar-resolver/properties").toFile()
     def resolverProperties = new JsonSlurper().parse(resolverPropertiesFile)
+    def jvmJarDirectory = projectDir.resolve("subdependency/build/libs").toRealPath()
     def jvmJarPath = resolverProperties.compileClasspath.find {
-      it.startsWith(projectDir.resolve("subdependency/build/libs").toAbsolutePath().toString()) && it.endsWith(".jar")
+      def classpathEntry = existingRealPathOrNormalizedPath(it)
+      classpathEntry.parent == jvmJarDirectory && classpathEntry.fileName.toString().endsWith(".jar")
     }
     jvmJarPath != null
 

--- a/src/test/groovy/org/sonarqube/gradle/FunctionalTests.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/FunctionalTests.groovy
@@ -19,6 +19,7 @@
  */
 package org.sonarqube.gradle
 
+import groovy.json.JsonSlurper
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.IgnoreIf
@@ -980,6 +981,89 @@ class FunctionalTests extends Specification {
      assert run3.task(":sonar").getOutcome() == SUCCESS
      assert run3.task(":sonarResolver").getOutcome() == SUCCESS
    }
+
+  def "sonarResolver tracks Java resource outputs through their producer"() {
+    given:
+    settingsFile << "rootProject.name = 'root'"
+    buildFile << """
+        plugins {
+            id 'org.sonarqube'
+            id 'java-library'
+        }
+        """
+    writeFile(projectDir.resolve("src/main/resources/f.txt"), "x")
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(projectDir.toFile())
+      .withGradleVersion("9.5.1")
+      .forwardOutput()
+      .withPluginClasspath()
+      .withArguments(':processResources', ':sonarResolver')
+      .build()
+
+    then:
+    result.task(":processResources").getOutcome() == SUCCESS
+    result.task(":sonarResolver").getOutcome() == SUCCESS
+    def resolverPropertiesFile = projectDir.resolve("build/sonar-resolver/properties").toFile()
+    def resolverProperties = new JsonSlurper().parse(resolverPropertiesFile)
+    def resourcesOutput = projectDir.resolve("build/resources/main").toAbsolutePath().toString()
+    new File(resourcesOutput).exists()
+    resolverProperties.testCompileClasspath.contains(resourcesOutput)
+  }
+
+  def "sonarResolver tracks a Kotlin Multiplatform JVM artifact through jvmJar"() {
+    given:
+    settingsFile << """
+        pluginManagement { repositories { gradlePluginPortal(); mavenCentral() } }
+        rootProject.name = 'root'
+        include 'consumer', 'subdependency'
+        """
+    buildFile << """
+        plugins {
+            id 'org.sonarqube'
+            id 'org.jetbrains.kotlin.multiplatform' version '2.2.20' apply false
+        }
+
+        allprojects { repositories { mavenCentral() } }
+
+        project(':subdependency') {
+            apply plugin: 'org.jetbrains.kotlin.multiplatform'
+            kotlin { jvm() }
+        }
+
+        project(':consumer') {
+            apply plugin: 'java-library'
+            dependencies { implementation project(':subdependency') }
+        }
+        """
+    writeFile(
+      projectDir.resolve("subdependency/src/commonMain/kotlin/example/Dependency.kt"),
+      "package example\nclass Dependency"
+    )
+    writeFile(
+      projectDir.resolve("consumer/src/main/java/example/Consumer.java"),
+      "package example;\npublic class Consumer {}"
+    )
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(projectDir.toFile())
+      .withGradleVersion("9.5.1")
+      .forwardOutput()
+      .withPluginClasspath()
+      .withArguments(':consumer:sonarResolver')
+      .build()
+
+    then:
+    result.task(":subdependency:jvmJar").getOutcome() == SUCCESS
+    result.task(":consumer:sonarResolver").getOutcome() == SUCCESS
+    def resolverPropertiesFile = projectDir.resolve("consumer/build/sonar-resolver/properties").toFile()
+    def resolverProperties = new JsonSlurper().parse(resolverPropertiesFile)
+    resolverProperties.compileClasspath.any {
+      it.startsWith(projectDir.resolve("subdependency/build/libs").toAbsolutePath().toString()) && it.endsWith(".jar")
+    }
+  }
 
   private Path projectDir(String project) {
     return Path.of("src", "test", "projects", project)

--- a/src/test/groovy/org/sonarqube/gradle/FunctionalTests.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/FunctionalTests.groovy
@@ -1017,7 +1017,8 @@ class FunctionalTests extends Specification {
     given:
     settingsFile << "rootProject.name = 'root'"
     Files.createDirectories(projectDir.resolve("empty-repository"))
-    writeFile(projectDir.resolve("existing-library.txt"), "existing library")
+    def existingLibrary = projectDir.resolve("existing-library.txt")
+    writeFile(existingLibrary, "existing library")
     buildFile << """
         plugins {
             id 'org.sonarqube'
@@ -1053,6 +1054,7 @@ class FunctionalTests extends Specification {
     def resolverProperties = new JsonSlurper().parse(resolverPropertiesFile)
     resolverProperties.compileClasspath.isEmpty()
     resolverProperties.testCompileClasspath.isEmpty()
+    resolverProperties.mainLibraries == [existingLibrary.toAbsolutePath().toString()]
   }
 
   def "sonarResolver tracks a Kotlin Multiplatform JVM artifact through jvmJar"() {

--- a/src/test/groovy/org/sonarqube/gradle/SonarQubePluginTest.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/SonarQubePluginTest.groovy
@@ -163,7 +163,7 @@ class SonarQubePluginTest extends Specification {
     ])
   }
 
-  def "makes sonar resolver task depend on classpath producers and run after compile tasks"() {
+  def "makes sonar resolver task run after classpath producers without depending on them"() {
     when:
     parentProject.pluginManager.apply(JavaPlugin)
     childProject.pluginManager.apply(JavaPlugin)
@@ -175,20 +175,14 @@ class SonarQubePluginTest extends Specification {
       "parent:compileJava",
       "parent:compileTestJava",
     ])
-    dependsOnTasks(parentResolverTask).containsAll([
-      "classes",
-      "compileJava",
-    ])
+    dependsOnTasks(parentResolverTask).isEmpty()
 
     def skippedChildResolverTask = childProject.tasks.sonarResolver
     mustRunAfterTasks(skippedChildResolverTask).containsAll([
       "child:compileJava",
       "child:compileTestJava",
     ])
-    dependsOnTasks(skippedChildResolverTask).containsAll([
-      "classes",
-      "compileJava",
-    ])
+    dependsOnTasks(skippedChildResolverTask).isEmpty()
   }
 
   def "sonar resolver retains the complete source set classpaths"() {

--- a/src/test/groovy/org/sonarqube/gradle/SonarQubePluginTest.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/SonarQubePluginTest.groovy
@@ -213,8 +213,8 @@ class SonarQubePluginTest extends Specification {
     testClasspath.containsAll(ownOutputPaths)
 
     // External dependencies must still be present.
-    mainClasspath.any { it.endsWith("lib/SomeLib.jar") }
-    testClasspath.any { it.endsWith("lib/junit.jar") }
+    mainClasspath.any { Path.of(it).endsWith(Path.of("lib", "SomeLib.jar")) }
+    testClasspath.any { Path.of(it).endsWith(Path.of("lib", "junit.jar")) }
   }
 
   def "doesn't make sonar task depend on test task of skipped projects"() {

--- a/src/test/groovy/org/sonarqube/gradle/SonarQubePluginTest.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/SonarQubePluginTest.groovy
@@ -163,7 +163,7 @@ class SonarQubePluginTest extends Specification {
     ])
   }
 
-  def "makes sonar resolver task run after compile tasks without depending on them"() {
+  def "makes sonar resolver task depend on classpath producers and run after compile tasks"() {
     when:
     parentProject.pluginManager.apply(JavaPlugin)
     childProject.pluginManager.apply(JavaPlugin)
@@ -175,14 +175,52 @@ class SonarQubePluginTest extends Specification {
       "parent:compileJava",
       "parent:compileTestJava",
     ])
-    dependsOnTasks(parentResolverTask).isEmpty()
+    dependsOnTasks(parentResolverTask).containsAll([
+      "classes",
+      "compileJava",
+    ])
 
     def skippedChildResolverTask = childProject.tasks.sonarResolver
     mustRunAfterTasks(skippedChildResolverTask).containsAll([
       "child:compileJava",
       "child:compileTestJava",
     ])
-    dependsOnTasks(skippedChildResolverTask).isEmpty()
+    dependsOnTasks(skippedChildResolverTask).containsAll([
+      "classes",
+      "compileJava",
+    ])
+  }
+
+  def "sonar resolver retains the complete source set classpaths"() {
+    when:
+    def project = ProjectBuilder.builder().withName("root").withProjectDir(new File("src/test/projects/java-project")).build()
+    project.pluginManager.apply(SonarQubePlugin)
+    project.pluginManager.apply(JavaPlugin)
+    setOutputDirs(project, "classes/main", "classes/test")
+    project.sourceSets.main.output.setResourcesDir(new File(project.buildDir, "resources/main"))
+    project.sourceSets.test.output.setResourcesDir(new File(project.buildDir, "resources/test"))
+    def ownOutputDirs = []
+    ownOutputDirs.addAll(project.sourceSets.main.output.classesDirs.files)
+    ownOutputDirs.add(project.sourceSets.main.output.resourcesDir)
+    ownOutputDirs.addAll(project.sourceSets.test.output.classesDirs.files)
+    ownOutputDirs.add(project.sourceSets.test.output.resourcesDir)
+    ownOutputDirs.each { it.mkdirs() }
+    // A test classpath can contain output dirs of any source set.
+    project.sourceSets.test.compileClasspath += project.files(ownOutputDirs)
+    project.sourceSets.main.compileClasspath += project.files("lib/SomeLib.jar")
+    project.sourceSets.test.compileClasspath += project.files("lib/junit.jar")
+
+    then:
+    def resolverTask = project.tasks.sonarResolver
+    def mainClasspath = resolverTask.compileClasspath.files*.absolutePath
+    def testClasspath = resolverTask.testCompileClasspath.files*.absolutePath
+    def ownOutputPaths = ownOutputDirs*.absolutePath as Set
+
+    testClasspath.containsAll(ownOutputPaths)
+
+    // External dependencies must still be present.
+    mainClasspath.any { it.endsWith("lib/SomeLib.jar") }
+    testClasspath.any { it.endsWith("lib/junit.jar") }
   }
 
   def "doesn't make sonar task depend on test task of skipped projects"() {

--- a/src/test/groovy/org/sonarqube/gradle/SonarResolverTaskTest.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/SonarResolverTaskTest.groovy
@@ -31,6 +31,29 @@ class SonarResolverTaskTest extends Specification {
   @TempDir
   Path projectDir
 
+  def "tracked classpaths retain producer dependencies while filtering missing entries"() {
+    given:
+    def project = ProjectBuilder.builder().withProjectDir(projectDir.toFile()).build()
+    def compileProducer = project.tasks.register("compileProducer")
+    def testProducer = project.tasks.register("testProducer")
+    def existingCompileEntry = Files.createFile(projectDir.resolve("compile-entry.jar")).toFile()
+    def missingCompileEntry = projectDir.resolve("missing-compile-entry.jar").toFile()
+    def existingTestEntry = Files.createFile(projectDir.resolve("test-entry.jar")).toFile()
+    def missingTestEntry = projectDir.resolve("missing-test-entry.jar").toFile()
+    def compileClasspath = project.files(existingCompileEntry, missingCompileEntry).builtBy(compileProducer)
+    def testCompileClasspath = project.files(existingTestEntry, missingTestEntry).builtBy(testProducer)
+    def task = project.tasks.create(SonarResolverTask.TASK_NAME, SonarResolverTask)
+
+    when:
+    task.setCompileClasspath(project.provider { compileClasspath })
+    task.setTestCompileClasspath(project.provider { testCompileClasspath })
+
+    then:
+    task.compileClasspath.files == [existingCompileEntry] as Set
+    task.testCompileClasspath.files == [existingTestEntry] as Set
+    task.taskDependencies.getDependencies(task).containsAll(compileProducer.get(), testProducer.get())
+  }
+
   def "run skips file collection inputs that fail to resolve"() {
     given:
     def project = ProjectBuilder.builder().withProjectDir(projectDir.toFile()).build()

--- a/src/test/groovy/org/sonarqube/gradle/SonarResolverTaskTest.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/SonarResolverTaskTest.groovy
@@ -31,11 +31,15 @@ class SonarResolverTaskTest extends Specification {
   @TempDir
   Path projectDir
 
-  def "tracked classpaths retain producer dependencies and missing entries"() {
+  def "tracked classpaths retain producer ordering and missing entries without adding dependencies"() {
     given:
     def project = ProjectBuilder.builder().withProjectDir(projectDir.toFile()).build()
+    def compileDependency = project.tasks.register("compileDependency")
+    def testDependency = project.tasks.register("testDependency")
     def compileProducer = project.tasks.register("compileProducer")
     def testProducer = project.tasks.register("testProducer")
+    compileProducer.configure { dependsOn(compileDependency) }
+    testProducer.configure { dependsOn(testDependency) }
     def existingCompileEntry = Files.createFile(projectDir.resolve("compile-entry.jar")).toFile()
     def missingCompileEntry = projectDir.resolve("missing-compile-entry.jar").toFile()
     def existingTestEntry = Files.createFile(projectDir.resolve("test-entry.jar")).toFile()
@@ -56,7 +60,10 @@ class SonarResolverTaskTest extends Specification {
     then:
     task.compileClasspath.files == [existingCompileEntry, missingCompileEntry] as Set
     task.testCompileClasspath.files == [existingTestEntry, missingTestEntry] as Set
-    task.taskDependencies.getDependencies(task).containsAll(compileProducer.get(), testProducer.get())
+    task.mustRunAfter.getDependencies(task).containsAll(
+      compileProducer.get(), compileDependency.get(), testProducer.get(), testDependency.get()
+    )
+    task.taskDependencies.getDependencies(task).isEmpty()
     def properties = ResolutionSerializer.read(task.outputFile).get()
     properties.compileClasspath == [existingCompileEntry.absolutePath]
     properties.testCompileClasspath == [existingTestEntry.absolutePath]

--- a/src/test/groovy/org/sonarqube/gradle/SonarResolverTaskTest.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/SonarResolverTaskTest.groovy
@@ -46,7 +46,7 @@ class SonarResolverTaskTest extends Specification {
     def missingTestEntry = projectDir.resolve("missing-test-entry.jar").toFile()
     def compileClasspath = project.files(existingCompileEntry, missingCompileEntry).builtBy(compileProducer)
     def testCompileClasspath = project.files(existingTestEntry, missingTestEntry).builtBy(testProducer)
-    def task = project.tasks.create(SonarResolverTask.TASK_NAME, SonarResolverTask)
+    def task = project.tasks.register(SonarResolverTask.TASK_NAME, SonarResolverTask).get()
     task.projectName.set(":")
     task.topLevelProject.set(true)
     task.skipProject.set(false)

--- a/src/test/groovy/org/sonarqube/gradle/SonarResolverTaskTest.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/SonarResolverTaskTest.groovy
@@ -31,7 +31,7 @@ class SonarResolverTaskTest extends Specification {
   @TempDir
   Path projectDir
 
-  def "tracked classpaths retain producer dependencies while filtering missing entries"() {
+  def "tracked classpaths retain producer dependencies and missing entries"() {
     given:
     def project = ProjectBuilder.builder().withProjectDir(projectDir.toFile()).build()
     def compileProducer = project.tasks.register("compileProducer")
@@ -43,15 +43,23 @@ class SonarResolverTaskTest extends Specification {
     def compileClasspath = project.files(existingCompileEntry, missingCompileEntry).builtBy(compileProducer)
     def testCompileClasspath = project.files(existingTestEntry, missingTestEntry).builtBy(testProducer)
     def task = project.tasks.create(SonarResolverTask.TASK_NAME, SonarResolverTask)
+    task.projectName.set(":")
+    task.topLevelProject.set(true)
+    task.skipProject.set(false)
+    task.setOutputDirectory(projectDir.resolve("sonar-resolver").toFile())
 
     when:
     task.setCompileClasspath(project.provider { compileClasspath })
     task.setTestCompileClasspath(project.provider { testCompileClasspath })
+    task.run()
 
     then:
-    task.compileClasspath.files == [existingCompileEntry] as Set
-    task.testCompileClasspath.files == [existingTestEntry] as Set
+    task.compileClasspath.files == [existingCompileEntry, missingCompileEntry] as Set
+    task.testCompileClasspath.files == [existingTestEntry, missingTestEntry] as Set
     task.taskDependencies.getDependencies(task).containsAll(compileProducer.get(), testProducer.get())
+    def properties = ResolutionSerializer.read(task.outputFile).get()
+    properties.compileClasspath == [existingCompileEntry.absolutePath]
+    properties.testCompileClasspath == [existingTestEntry.absolutePath]
   }
 
   def "run skips file collection inputs that fail to resolve"() {


### PR DESCRIPTION
- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Provide a unit test for any code you changed
- [x] If there is a [JIRA](http://jira.sonarsource.com/browse/SONARGRADL) ticket available, please make your commits and pull request start with the ticket ID (SONARGRADL-XXXX)

https://community.sonarsource.com/t/sonarscanner-for-gradle-7-4-0-8496-analysis-failing/187171

This PR fixes Gradle implicit-dependency validation failures when `sonarResolver` and tasks producing its compile or test classpaths are selected in the same invocation.

## Motivation

SCANGRADLE-432 / #517 added `@Classpath` tracking for the resolver compile and test classpaths. While collecting those entries, the resolver mapped each producer-aware `FileCollection` to `List<File>`.

That retained the file paths but discarded Gradle’s task-producer metadata. As a result, `sonarResolver` could consume outputs such as `build/resources/main` or a Kotlin Multiplatform JVM JAR without an ordering relationship with the task that produced them. Gradle then reported an implicit-dependency validation error.

Using the producer-aware collection directly as the task input would make `sonarResolver` depend on and automatically schedule those producers. That would conflict with the plugin's established behavior of allowing build and analysis tasks to run in separate invocations.

## Change

Separate tracked classpath values from producer-task ordering:

- Continue resolving the tracked `@Classpath` values through the guarded   mapping, preserving the existing warning-and-skip behavior for classpaths  that cannot be resolved.
- Lazily derive producer tasks from the original provider-backed `FileCollection` and add them through `mustRunAfter`, without adding task dependencies.
- Include transitive producer dependencies so concrete tasks such as `processResources` are ordered correctly even when an aggregate task such as `classes` is not selected.
- Keep missing producer outputs in the tracked classpath for stable configuration-cache reuse, while excluding nonexistent entries from the serialized resolver properties.

This allows Gradle to order selected producers before `sonarResolver` without causing a resolver-only invocation to schedule compilation or artifact tasks.

## Tests

New regression coverage verifies that:

- Compile and test classpath producers contribute direct and transitive ordering relationships without becoming task dependencies.
- `processResources` runs before `sonarResolver`, and its resource output remains part of the serialized classpath.
- A cross-project Kotlin Multiplatform `jvmJar` runs before the consumer's `sonarResolver` when both tasks are selected.
- A resolver-only invocation consumes an existing KMP JAR without scheduling `jvmJar`.
- Unresolvable classpaths emit the existing warning and are serialized as empty instead of failing the resolver.
- Configuration-cache reuse and classpath up-to-date tracking remain stable.
- Skipped projects do not create resolver output directories.

`./gradlew check` passes with JDK 21.