### PR TITLE
SCANGRADLE-441 Preserve classpath producer dependencies in sonarResolver

### DIFF
--- a/src/main/java/org/sonarqube/gradle/SonarResolverTask.java
+++ b/src/main/java/org/sonarqube/gradle/SonarResolverTask.java
@@ -21,9 +21,13 @@ package org.sonarqube.gradle;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Queue;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -31,6 +35,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.Task;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Property;
@@ -42,6 +47,7 @@ import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.TaskDependency;
 
 
 public abstract class SonarResolverTask extends DefaultTask {
@@ -49,6 +55,7 @@ public abstract class SonarResolverTask extends DefaultTask {
   public static final String TASK_DESCRIPTION = "Resolves and serializes project information and classpath for SonarQube analysis.";
   private static final Logger LOGGER = Logger.getLogger(SonarResolverTask.class.getName());
   private static final String FILE_COLLECTION_RESOLUTION_FAILURE_MESSAGE = "Failed to resolve file collection input; skipping it.";
+  private static final String PRODUCER_ORDERING_FAILURE_MESSAGE = "Failed to resolve classpath producer tasks; sonarResolver will not be ordered after them.";
 
   private final ConfigurableFileCollection trackedCompileClasspath;
   private final ConfigurableFileCollection trackedTestCompileClasspath;
@@ -76,12 +83,14 @@ public abstract class SonarResolverTask extends DefaultTask {
 
   public void setCompileClasspath(Provider<FileCollection> compileClasspath) {
     this.compileClasspath = compileClasspath;
-    this.getCompileClasspath().setFrom(compileClasspath.map(SonarResolverTask::getExistingClasspathEntries));
+    this.getCompileClasspath().setFrom(compileClasspath.map(SonarResolverTask::getClasspathEntries));
+    this.mustRunAfter(getClasspathProducerOrdering(compileClasspath));
   }
 
   public void setTestCompileClasspath(Provider<FileCollection> testCompileClasspath) {
     this.testCompileClasspath = testCompileClasspath;
-    this.getTestCompileClasspath().setFrom(testCompileClasspath.map(SonarResolverTask::getExistingClasspathEntries));
+    this.getTestCompileClasspath().setFrom(testCompileClasspath.map(SonarResolverTask::getClasspathEntries));
+    this.mustRunAfter(getClasspathProducerOrdering(testCompileClasspath));
   }
 
   public void setLegacyMainLibraries(Provider<FileCollection> legacyMainLibraries) {
@@ -171,13 +180,52 @@ public abstract class SonarResolverTask extends DefaultTask {
     return filenames;
   }
 
-  private static List<File> getExistingClasspathEntries(FileCollection fileCollection) {
+  private static List<File> getClasspathEntries(FileCollection fileCollection) {
     try {
-      return SonarUtils.exists(fileCollection);
+      // Keep missing producer outputs in the tracked value so configuration-cache state does not depend on
+      // whether those outputs exist while Gradle constructs the task graph. Serialization filters them later.
+      return new ArrayList<>(fileCollection.getFiles());
     } catch (RuntimeException e) {
       LOGGER.log(Level.WARNING, FILE_COLLECTION_RESOLUTION_FAILURE_MESSAGE, e);
       return Collections.emptyList();
     }
+  }
+
+  /**
+   * Lazily finds all tasks that may produce the classpath.
+   * <p>
+   * A FileCollection can expose an aggregate producer such as {@code classes}. If only one of its dependencies, such
+   * as {@code processResources}, is selected, the aggregate task is absent from the task graph. Ordering sonarResolver
+   * only after the aggregate task would therefore not satisfy Gradle's implicit-dependency validation.
+   * <p>
+   * Including transitive task dependencies ensures every selected concrete producer is ordered before sonarResolver,
+   * without making it a task dependency.
+   */
+  private static TaskDependency getClasspathProducerOrdering(Provider<FileCollection> filesProvider) {
+    return task -> {
+      try {
+        FileCollection files = filesProvider.getOrNull();
+        if (files == null) {
+          return Collections.emptySet();
+        }
+        return collectTransitiveTaskDependencies(task, files.getBuildDependencies().getDependencies(task));
+      } catch (RuntimeException e) {
+        LOGGER.log(Level.WARNING, PRODUCER_ORDERING_FAILURE_MESSAGE, e);
+        return Collections.emptySet();
+      }
+    };
+  }
+
+  private static Set<Task> collectTransitiveTaskDependencies(Task consumer, Set<? extends Task> producerTasks) {
+    Set<Task> producersToOrderAfter = new HashSet<>();
+    Queue<Task> queue = new ArrayDeque<>(producerTasks);
+    while (!queue.isEmpty()) {
+      Task producer = queue.remove();
+      if (producer != consumer && producersToOrderAfter.add(producer)) {
+        queue.addAll(producer.getTaskDependencies().getDependencies(producer));
+      }
+    }
+    return producersToOrderAfter;
   }
 
   @TaskAction

--- a/src/test/groovy/org/sonarqube/gradle/FunctionalTests.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/FunctionalTests.groovy
@@ -19,6 +19,7 @@
  */
 package org.sonarqube.gradle
 
+import groovy.json.JsonSlurper
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.IgnoreIf
@@ -46,6 +47,11 @@ class FunctionalTests extends Specification {
     Path outFile
 
     def setup() {
+        // Gradle canonicalizes the project directory it is given, while @TempDir derives from java.io.tmpdir.
+        // On Windows CI those differ: java.io.tmpdir uses the 8.3 short name (C:\Users\RUNNER~1\...) whereas
+        // every path reported by the build uses the long name (C:\Users\runneradmin\...). Normalize once here so
+        // that paths built from projectDir can be compared with paths coming out of the build.
+        projectDir = projectDir.toRealPath()
         settingsFile = projectDir.resolve('settings.gradle')
         buildFile = projectDir.resolve('build.gradle')
         projectDir.resolve('integrationTests').toFile().mkdir()
@@ -799,7 +805,7 @@ class FunctionalTests extends Specification {
     then:
     def sonarResolver = multiModuleProjectDir.resolve("module-1/build/sonar-resolver")
     assert result.task(":sonar").getOutcome() == SUCCESS
-    assert Files.list(sonarResolver).count() == 0
+    assert Files.notExists(sonarResolver.resolve("properties"))
 
   }
 
@@ -980,6 +986,152 @@ class FunctionalTests extends Specification {
      assert run3.task(":sonar").getOutcome() == SUCCESS
      assert run3.task(":sonarResolver").getOutcome() == SUCCESS
    }
+
+  def "sonarResolver tracks Java resource outputs through their producer"() {
+    given:
+    settingsFile << "rootProject.name = 'root'"
+    buildFile << """
+        plugins {
+            id 'org.sonarqube'
+            id 'java-library'
+        }
+        """
+    writeFile(projectDir.resolve("src/main/resources/f.txt"), "x")
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(projectDir.toFile())
+      .withGradleVersion("9.5.1")
+      .forwardOutput()
+      .withPluginClasspath()
+      .withArguments(':sonarResolver', ':processResources')
+      .build()
+
+    then:
+    result.task(":processResources").getOutcome() == SUCCESS
+    result.task(":sonarResolver").getOutcome() == SUCCESS
+    result.tasks*.path.indexOf(":processResources") < result.tasks*.path.indexOf(":sonarResolver")
+    def resolverPropertiesFile = projectDir.resolve("build/sonar-resolver/properties").toFile()
+    def resolverProperties = new JsonSlurper().parse(resolverPropertiesFile)
+    def resourcesOutput = projectDir.resolve("build/resources/main").toAbsolutePath().toString()
+    new File(resourcesOutput).exists()
+    resolverProperties.testCompileClasspath.contains(resourcesOutput)
+  }
+
+  def "sonarResolver skips compile classpaths that fail to resolve"() {
+    given:
+    settingsFile << "rootProject.name = 'root'"
+    Files.createDirectories(projectDir.resolve("empty-repository"))
+    def existingLibrary = projectDir.resolve("existing-library.txt")
+    writeFile(existingLibrary, "existing library")
+    buildFile << """
+        plugins {
+            id 'org.sonarqube'
+            id 'java-library'
+        }
+
+        repositories {
+            maven { url = uri('empty-repository') }
+        }
+
+        dependencies {
+            implementation 'invalid.example:missing-artifact:1.0'
+        }
+
+        tasks.named('sonarResolver') {
+            mainLibraries.from(file('existing-library.txt'))
+        }
+        """
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(projectDir.toFile())
+      .withGradleVersion("9.5.1")
+      .forwardOutput()
+      .withPluginClasspath()
+      .withArguments(':sonarResolver')
+      .build()
+
+    then:
+    result.task(":sonarResolver").getOutcome() == SUCCESS
+    result.output.contains("Failed to resolve file collection input; skipping it.")
+    def resolverPropertiesFile = projectDir.resolve("build/sonar-resolver/properties").toFile()
+    def resolverProperties = new JsonSlurper().parse(resolverPropertiesFile)
+    resolverProperties.compileClasspath.isEmpty()
+    resolverProperties.testCompileClasspath.isEmpty()
+    resolverProperties.mainLibraries == [existingLibrary.toString()]
+  }
+
+  def "sonarResolver tracks a Kotlin Multiplatform JVM artifact through jvmJar"() {
+    given:
+    settingsFile << """
+        pluginManagement { repositories { gradlePluginPortal(); mavenCentral() } }
+        rootProject.name = 'root'
+        include 'consumer', 'subdependency'
+        """
+    buildFile << """
+        plugins {
+            id 'org.sonarqube'
+            id 'org.jetbrains.kotlin.multiplatform' version '2.2.20' apply false
+        }
+
+        allprojects { repositories { mavenCentral() } }
+
+        project(':subdependency') {
+            apply plugin: 'org.jetbrains.kotlin.multiplatform'
+            kotlin { jvm() }
+        }
+
+        project(':consumer') {
+            apply plugin: 'java-library'
+            dependencies { implementation project(':subdependency') }
+        }
+        """
+    writeFile(
+      projectDir.resolve("subdependency").resolve("src").resolve("commonMain").resolve("kotlin").resolve("example").resolve("Dependency.kt"),
+      "package example\nclass Dependency"
+    )
+    writeFile(
+      projectDir.resolve("consumer").resolve("src").resolve("main").resolve("java").resolve("example").resolve("Consumer.java"),
+      "package example;\npublic class Consumer {}"
+    )
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(projectDir.toFile())
+      .withGradleVersion("9.5.1")
+      .forwardOutput()
+      .withPluginClasspath()
+      .withArguments(':consumer:sonarResolver', ':subdependency:jvmJar')
+      .build()
+
+    then:
+    result.task(":subdependency:jvmJar").getOutcome() == SUCCESS
+    result.task(":consumer:sonarResolver").getOutcome() == SUCCESS
+    result.tasks*.path.indexOf(":subdependency:jvmJar") < result.tasks*.path.indexOf(":consumer:sonarResolver")
+    def resolverPropertiesFile = projectDir.resolve("consumer").resolve("build").resolve("sonar-resolver").resolve("properties").toFile()
+    def resolverProperties = new JsonSlurper().parse(resolverPropertiesFile)
+    def jvmJarPath = resolverProperties.compileClasspath.find {
+      it.startsWith(projectDir.resolve("subdependency").resolve("build").resolve("libs").toAbsolutePath().toString()) && it.endsWith(".jar")
+    }
+    jvmJarPath != null
+
+    when:
+    Files.delete(resolverPropertiesFile.toPath())
+    def resolverOnlyResult = GradleRunner.create()
+      .withProjectDir(projectDir.toFile())
+      .withGradleVersion("9.5.1")
+      .forwardOutput()
+      .withPluginClasspath()
+      .withArguments(':consumer:sonarResolver', '--rerun-tasks')
+      .build()
+
+    then:
+    resolverOnlyResult.task(":subdependency:jvmJar") == null
+    resolverOnlyResult.task(":consumer:sonarResolver").getOutcome() == SUCCESS
+    def resolverOnlyProperties = new JsonSlurper().parse(resolverPropertiesFile)
+    resolverOnlyProperties.compileClasspath.contains(jvmJarPath)
+  }
 
   private Path projectDir(String project) {
     return Path.of("src", "test", "projects", project)

--- a/src/test/groovy/org/sonarqube/gradle/SonarQubePluginTest.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/SonarQubePluginTest.groovy
@@ -163,7 +163,7 @@ class SonarQubePluginTest extends Specification {
     ])
   }
 
-  def "makes sonar resolver task run after compile tasks without depending on them"() {
+  def "makes sonar resolver task run after classpath producers without depending on them"() {
     when:
     parentProject.pluginManager.apply(JavaPlugin)
     childProject.pluginManager.apply(JavaPlugin)
@@ -183,6 +183,38 @@ class SonarQubePluginTest extends Specification {
       "child:compileTestJava",
     ])
     dependsOnTasks(skippedChildResolverTask).isEmpty()
+  }
+
+  def "sonar resolver retains the complete source set classpaths"() {
+    when:
+    def project = ProjectBuilder.builder().withName("root").withProjectDir(new File("src/test/projects/java-project")).build()
+    project.pluginManager.apply(SonarQubePlugin)
+    project.pluginManager.apply(JavaPlugin)
+    setOutputDirs(project, "classes/main", "classes/test")
+    project.sourceSets.main.output.setResourcesDir(new File(project.buildDir, "resources/main"))
+    project.sourceSets.test.output.setResourcesDir(new File(project.buildDir, "resources/test"))
+    def ownOutputDirs = []
+    ownOutputDirs.addAll(project.sourceSets.main.output.classesDirs.files)
+    ownOutputDirs.add(project.sourceSets.main.output.resourcesDir)
+    ownOutputDirs.addAll(project.sourceSets.test.output.classesDirs.files)
+    ownOutputDirs.add(project.sourceSets.test.output.resourcesDir)
+    ownOutputDirs.each { it.mkdirs() }
+    // A test classpath can contain output dirs of any source set.
+    project.sourceSets.test.compileClasspath += project.files(ownOutputDirs)
+    project.sourceSets.main.compileClasspath += project.files("lib/SomeLib.jar")
+    project.sourceSets.test.compileClasspath += project.files("lib/junit.jar")
+
+    then:
+    def resolverTask = project.tasks.sonarResolver
+    def mainClasspath = resolverTask.compileClasspath.files*.absolutePath
+    def testClasspath = resolverTask.testCompileClasspath.files*.absolutePath
+    def ownOutputPaths = ownOutputDirs*.absolutePath as Set
+
+    testClasspath.containsAll(ownOutputPaths)
+
+    // External dependencies must still be present.
+    mainClasspath.any { it.endsWith("lib${File.separator}SomeLib.jar") }
+    testClasspath.any { it.endsWith("lib${File.separator}junit.jar") }
   }
 
   def "doesn't make sonar task depend on test task of skipped projects"() {

--- a/src/test/groovy/org/sonarqube/gradle/SonarResolverTaskTest.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/SonarResolverTaskTest.groovy
@@ -31,6 +31,44 @@ class SonarResolverTaskTest extends Specification {
   @TempDir
   Path projectDir
 
+  def "tracked classpaths retain producer ordering and missing entries without adding dependencies"() {
+    given:
+    def project = ProjectBuilder.builder().withProjectDir(projectDir.toFile()).build()
+    def compileDependency = project.tasks.register("compileDependency")
+    def testDependency = project.tasks.register("testDependency")
+    def compileProducer = project.tasks.register("compileProducer")
+    def testProducer = project.tasks.register("testProducer")
+    compileProducer.configure { dependsOn(compileDependency) }
+    testProducer.configure { dependsOn(testDependency) }
+    def existingCompileEntry = Files.createFile(projectDir.resolve("compile-entry.jar")).toFile()
+    def missingCompileEntry = projectDir.resolve("missing-compile-entry.jar").toFile()
+    def existingTestEntry = Files.createFile(projectDir.resolve("test-entry.jar")).toFile()
+    def missingTestEntry = projectDir.resolve("missing-test-entry.jar").toFile()
+    def compileClasspath = project.files(existingCompileEntry, missingCompileEntry).builtBy(compileProducer)
+    def testCompileClasspath = project.files(existingTestEntry, missingTestEntry).builtBy(testProducer)
+    def task = project.tasks.register(SonarResolverTask.TASK_NAME, SonarResolverTask).get()
+    task.projectName.set(":")
+    task.topLevelProject.set(true)
+    task.skipProject.set(false)
+    task.setOutputDirectory(projectDir.resolve("sonar-resolver").toFile())
+
+    when:
+    task.setCompileClasspath(project.provider { compileClasspath })
+    task.setTestCompileClasspath(project.provider { testCompileClasspath })
+    task.run()
+
+    then:
+    task.compileClasspath.files == [existingCompileEntry, missingCompileEntry] as Set
+    task.testCompileClasspath.files == [existingTestEntry, missingTestEntry] as Set
+    task.mustRunAfter.getDependencies(task).containsAll(
+      compileProducer.get(), compileDependency.get(), testProducer.get(), testDependency.get()
+    )
+    task.taskDependencies.getDependencies(task).isEmpty()
+    def properties = ResolutionSerializer.read(task.outputFile).get()
+    properties.compileClasspath == [existingCompileEntry.absolutePath]
+    properties.testCompileClasspath == [existingTestEntry.absolutePath]
+  }
+
   def "run skips file collection inputs that fail to resolve"() {
     given:
     def project = ProjectBuilder.builder().withProjectDir(projectDir.toFile()).build()


### PR DESCRIPTION
Copy of #532

----
## Summary by Gitar

- **Task ordering and dependencies:**
    - Order `sonarResolver` after transitive classpath producers using `mustRunAfter` without adding task dependencies
- **Classpath resolution:**
    - Preserve missing classpath producer outputs in tracked values for configuration-cache compatibility

<sub>This will update automatically on new commits.</sub>