### PR TITLE
SCANGRADLE-449 sonarResolver fails on composite builds: "Cannot use mustRunAfter to reference tasks from another build"

### DIFF
--- a/src/main/java/org/sonarqube/gradle/SonarResolverTask.java
+++ b/src/main/java/org/sonarqube/gradle/SonarResolverTask.java
@@ -38,6 +38,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.Task;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.invocation.Gradle;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Classpath;
@@ -192,7 +193,7 @@ public abstract class SonarResolverTask extends DefaultTask {
   }
 
   /**
-   * Lazily finds all tasks that may produce the classpath.
+   * Lazily finds all tasks of the consumer's own build that may produce the classpath.
    * <p>
    * A FileCollection can expose an aggregate producer such as {@code classes}. If only one of its dependencies, such
    * as {@code processResources}, is selected, the aggregate task is absent from the task graph. Ordering sonarResolver
@@ -200,6 +201,10 @@ public abstract class SonarResolverTask extends DefaultTask {
    * <p>
    * Including transitive task dependencies ensures every selected concrete producer is ordered before sonarResolver,
    * without making it a task dependency.
+   * <p>
+   * Tasks of an included build are left out: Gradle rejects {@code mustRunAfter} references to them with
+   * "Cannot use mustRunAfter to reference tasks from another build", and walking their dependencies resolves
+   * configurations of a build whose state lock we do not hold.
    */
   private static TaskDependency getClasspathProducerOrdering(Provider<FileCollection> filesProvider) {
     return task -> {
@@ -217,15 +222,20 @@ public abstract class SonarResolverTask extends DefaultTask {
   }
 
   private static Set<Task> collectTransitiveTaskDependencies(Task consumer, Set<? extends Task> producerTasks) {
+    Gradle consumerBuild = consumer.getProject().getGradle();
     Set<Task> producersToOrderAfter = new HashSet<>();
     Queue<Task> queue = new ArrayDeque<>(producerTasks);
     while (!queue.isEmpty()) {
       Task producer = queue.remove();
-      if (producer != consumer && producersToOrderAfter.add(producer)) {
+      if (producer != consumer && isPartOfBuild(producer, consumerBuild) && producersToOrderAfter.add(producer)) {
         queue.addAll(producer.getTaskDependencies().getDependencies(producer));
       }
     }
     return producersToOrderAfter;
+  }
+
+  private static boolean isPartOfBuild(Task task, Gradle build) {
+    return task.getProject().getGradle() == build;
   }
 
   @TaskAction

--- a/src/test/groovy/org/sonarqube/gradle/FunctionalTests.groovy
+++ b/src/test/groovy/org/sonarqube/gradle/FunctionalTests.groovy
@@ -1133,6 +1133,51 @@ class FunctionalTests extends Specification {
     resolverOnlyProperties.compileClasspath.contains(jvmJarPath)
   }
 
+  def "sonarResolver ignores classpath producers coming from an included build"() {
+    given:
+    settingsFile << """
+        rootProject.name = 'root'
+        includeBuild('included-lib') {
+            dependencySubstitution {
+                substitute module('com.example:included-lib') using project(':')
+            }
+        }
+        """
+    buildFile << """
+        plugins {
+            id 'org.sonarqube'
+            id 'java-library'
+        }
+
+        dependencies { implementation 'com.example:included-lib:1.0' }
+        """
+    writeFile(projectDir.resolve("included-lib/settings.gradle"), "rootProject.name = 'included-lib'")
+    writeFile(projectDir.resolve("included-lib/build.gradle"), """
+        plugins { id 'java-library' }
+        group = 'com.example'
+        version = '1.0'
+        """)
+    writeFile(projectDir.resolve("included-lib/src/main/java/example/Library.java"), "package example;\npublic class Library {}")
+    writeFile(projectDir.resolve("src/main/java/example/Consumer.java"), "package example;\npublic class Consumer {}")
+
+    when:
+    def result = GradleRunner.create()
+      .withProjectDir(projectDir.toFile())
+      .withGradleVersion("9.5.1")
+      .forwardOutput()
+      .withPluginClasspath()
+      .withArguments(':compileJava', ':sonarResolver')
+      .build()
+
+    then:
+    result.task(":sonarResolver").getOutcome() == SUCCESS
+    !result.output.contains("Failed to resolve classpath producer tasks")
+    !result.output.contains("Failed to resolve file collection input")
+    def resolverProperties = new JsonSlurper().parse(projectDir.resolve("build/sonar-resolver/properties").toFile())
+    def includedBuildOutput = projectDir.resolve("included-lib/build/classes/java/main").toString()
+    resolverProperties.compileClasspath.contains(includedBuildOutput)
+  }
+
   private Path projectDir(String project) {
     return Path.of("src", "test", "projects", project)
   }


### PR DESCRIPTION
----
## Summary by Gitar

- **Bug fix:**
    - Fixed `sonarResolver` failing on composite builds by ignoring classpath producer tasks from included builds.

<sub>This will update automatically on new commits.</sub>